### PR TITLE
[도효림] sprint3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,36 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.sprint.mission'
-version = '1.0-SNAPSHOT'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-test {
+tasks.named('test') {
     useJUnitPlatform()
 }

--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,0 +1,45 @@
+package com.sprint.mission.discodeit;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@SpringBootApplication
+public class DiscodeitApplication {
+
+    static User setupUser(UserService userService) {
+        User user = userService.createUser("woody", "woody@codeit.com", "woody1234");
+        return user;
+    }
+
+    static Channel setupChannel(ChannelService channelService) {
+        Channel channel = channelService.createChannel(ChannelType.PUBLIC, "공지", "공지 채널입니다.");
+        return channel;
+    }
+
+    static void messageCreateTest(MessageService messageService, User author, Channel channel) {
+        Message message = messageService.createMessage("안녕하세요.", author.getId(), channel.getId());
+        System.out.println("메시지 생성: " + message.getId());
+    }
+
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(DiscodeitApplication.class, args);
+
+        UserService userService = context.getBean(UserService.class);
+        ChannelService channelService = context.getBean(ChannelService.class);
+        MessageService messageService = context.getBean(MessageService.class);
+
+        User user = setupUser(userService);
+        Channel channel = setupChannel(channelService);
+        messageCreateTest(messageService, user, channel);
+
+    }
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
@@ -1,78 +1,53 @@
 package com.sprint.mission.discodeit;
 
-import com.sprint.mission.discodeit.service.jcf.JCFChannelService;
-import com.sprint.mission.discodeit.service.jcf.JCFMessageService;
-import com.sprint.mission.discodeit.service.jcf.JCFUserService;
-
-import java.util.UUID;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.file.FileChannelRepository;
+import com.sprint.mission.discodeit.repository.file.FileMessageRepository;
+import com.sprint.mission.discodeit.repository.file.FileUserRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.basic.BasicChannelService;
+import com.sprint.mission.discodeit.service.basic.BasicMessageService;
+import com.sprint.mission.discodeit.service.basic.BasicUserService;
 
 public class JavaApplication {
+    static User setupUser(UserService userService) {
+        User user = userService.createUser("woody", "woody@codeit.com", "woody1234");
+        return user;
+    }
+
+    static Channel setupChannel(ChannelService channelService) {
+        Channel channel = channelService.createChannel(ChannelType.PUBLIC, "공지", "공지 채널입니다.");
+        return channel;
+    }
+
+    static void messageCreateTest(MessageService messageService, User author, Channel channel) {
+        Message message = messageService.createMessage("안녕하세요.", author.getId(), channel.getId());
+        System.out.println("메시지 생성: " + message.getId());
+    }
+
     public static void main(String[] args) {
-        JCFUserService userservice = JCFUserService.getInstance();
-        JCFChannelService channelservice = JCFChannelService.getInstance();
-        JCFMessageService messageservice = JCFMessageService.getInstance(userservice, channelservice);
+        // 레포지토리 초기화
+        UserRepository userRepository = new FileUserRepository();
+        ChannelRepository channelRepository = new FileChannelRepository();
+        MessageRepository messageRepository = new FileMessageRepository();
 
-        // user 등록
-        UUID user1 = userservice.createUser("김이름");
-        UUID user2 = userservice.createUser("김연두");
-        UUID user3 = userservice.createUser("이비누");
-        //user 전체 조회
-        userservice.searchAllUsers();
-        //특정 user 조회
-        userservice.searchUser(user2);
-        //user 수정
-        userservice.updateUser(user2);
-        //수정된 user 조회
-        userservice.searchUser(user2);
-        //user 삭제
-        userservice.deleteUser(user1);
-        //삭제 확인
-        userservice.searchUser(user1);
+        // 서비스 초기화
+        UserService userService = new BasicUserService(userRepository);
+        ChannelService channelService = new BasicChannelService(channelRepository);
+        MessageService messageService = new BasicMessageService(messageRepository, userRepository, channelRepository);
 
-
-        // Channel 등록
-        UUID channel1 = channelservice.createChannel();
-        UUID channel2 = channelservice.createChannel();
-        //channel 전체 조회
-        channelservice.searchAllChannels();
-        //특정 channel 조회
-        channelservice.searchChannel(channel2);
-        //channel 수정
-        channelservice.updateChannel(channel2);
-        //수정된 channel 조회
-        channelservice.searchChannel(channel2);
-        //channel 삭제
-        channelservice.deleteChannel(channel1);
-        //삭제 확인
-        channelservice.searchChannel(channel1);
-
-
-        //Message 등록
-        UUID message1 = null;
-        try {
-            message1 = messageservice.createMessage(user2, channel1);
-        } catch (IllegalArgumentException e) {
-            System.out.println("ERROR: " + e.getMessage());
-        }
-        UUID message2 = null;
-        try {
-            message2 = messageservice.createMessage(user2, channel2);
-        } catch (IllegalArgumentException e) {
-            System.out.println("ERROR: " + e.getMessage());
-        }
-        //message 전체 조회
-        messageservice.searchAllMessages();
-        //특정 channel 조회
-        messageservice.searchMessage(message2);
-        //channel 수정
-        messageservice.updateMessage(message2);
-        //수정된 channel 조회
-        messageservice.searchMessage(message2);
-        //channel 삭제
-        messageservice.deleteMessage(message1);
-        //삭제 확인
-        messageservice.searchMessage(message1);
-
-
+        // 셋업
+        User user = setupUser(userService);
+        Channel channel = setupChannel(channelService);
+        // 테스트
+        messageCreateTest(messageService, user, channel);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/binaryContent/BinaryContentDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/binaryContent/BinaryContentDTO.java
@@ -1,0 +1,9 @@
+package com.sprint.mission.discodeit.dto.binaryContent;
+
+import java.util.UUID;
+
+public record BinaryContentDTO(
+        UUID binaryContentId
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/channel/ChannelResponseDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/channel/ChannelResponseDTO.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.dto.channel;
+
+import com.sprint.mission.discodeit.entity.ChannelType;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record ChannelResponseDTO(
+        UUID channelId,
+        ChannelType type,
+        String channelName,
+        String description,
+        Instant lastMessageAt,
+        List<UUID> userIds
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/channel/CreatePrivateChannelDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/channel/CreatePrivateChannelDTO.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.channel;
+
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+
+public record CreatePrivateChannelDTO(
+        List<User> userlist
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/channel/CreatePublicChannelDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/channel/CreatePublicChannelDTO.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.dto.channel;
+
+public record CreatePublicChannelDTO(
+        String channelName,
+        String description
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/channel/UpdateChannelDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/channel/UpdateChannelDTO.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.channel;
+
+import java.util.UUID;
+
+public record UpdateChannelDTO(
+        UUID channelId,
+        String channelName,
+        String description
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/message/CreateMessageDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/message/CreateMessageDTO.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.discodeit.dto.message;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateMessageDTO(
+        String text,
+        UUID userId,
+        UUID channelId,
+        List<UUID> attachmentIds
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/message/UpdateMessageDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/message/UpdateMessageDTO.java
@@ -1,0 +1,9 @@
+package com.sprint.mission.discodeit.dto.message;
+
+import java.util.UUID;
+
+public record UpdateMessageDTO(
+        UUID messageId,
+        String text
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/readStatus/CreateReadStatusDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/readStatus/CreateReadStatusDTO.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.dto.readStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record CreateReadStatusDTO(
+        UUID userId,
+        UUID channelId,
+        Instant readAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/readStatus/UpdateReadStatusDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/readStatus/UpdateReadStatusDTO.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.readStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UpdateReadStatusDTO(
+        UUID readStatusId,
+        Instant readAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/user/CreateUserDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/user/CreateUserDTO.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.dto.user;
+
+import java.util.UUID;
+
+public record CreateUserDTO(
+        String userName,
+        String email,
+        String password,
+        UUID profileId
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/user/LoginRequestDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/user/LoginRequestDTO.java
@@ -1,0 +1,4 @@
+package com.sprint.mission.discodeit.dto.user;
+
+public record LoginRequestDTO(String userName, String password) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/user/UpdateUserDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/user/UpdateUserDTO.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.discodeit.dto.user;
+
+import java.util.UUID;
+
+public record UpdateUserDTO(
+        UUID userId,
+        String userName,
+        String email,
+        String password,
+        UUID profileId
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/user/UserResponseDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/user/UserResponseDTO.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.dto.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserResponseDTO(
+        UUID userId,
+        Instant createdAt,
+        Instant updatedAt,
+        String userName,
+        String email,
+        UUID profiledId,
+        boolean isOnline
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/userStatus/CreateUserStatusDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/userStatus/CreateUserStatusDTO.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.userStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record CreateUserStatusDTO(
+        UUID userId,
+        Instant lastActiveAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/userStatus/UpdateUserStatusDTO.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/userStatus/UpdateUserStatusDTO.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.userStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UpdateUserStatusDTO(
+        UUID userId,
+        Instant lastActiveAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class BinaryContent {
+    private UUID id;
+    private Instant createdAt;
+
+    public BinaryContent() {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -1,16 +1,46 @@
 package com.sprint.mission.discodeit.entity;
 
-import java.io.Serializable;
+import lombok.Getter;
 
-public class Channel extends CommonEntity implements Serializable {
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class Channel implements Serializable {
     private static final long serialVersionUID = 1L;
-    public Channel() {
-        super();
+
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private ChannelType type;
+    private String channelName;
+    private String description;
+
+    public Channel(ChannelType type, String channelName, String description) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        this.updatedAt = createdAt;
+
+        this.type = type;
+        this.channelName = channelName;
+        this.description = description;
+
     }
 
-    @Override
+    public void updateChannel(String channelName, String description) {
+        if (channelName != null) {
+            this.channelName = channelName;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        this.updatedAt = Instant.now();
+    }
+
     public String toString() {
-        return "[CHANNEL " +super.toString();
+        return "[CHANNEL " + getId() + "channelName: " + getChannelName() + " ]";
 
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/ChannelType.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ChannelType.java
@@ -1,0 +1,5 @@
+package com.sprint.mission.discodeit.entity;
+
+public enum ChannelType {
+    PUBLIC, PRIVATE,
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -1,21 +1,43 @@
 package com.sprint.mission.discodeit.entity;
 
+import lombok.Getter;
+
 import java.io.Serializable;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
-public class Message extends CommonEntity implements Serializable {
+@Getter
+public class Message implements Serializable {
     private static final long serialVersionUID = 1L;
+
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private String text;
+    private List<UUID> attachmentIds;
+
     private UUID userId;
     private UUID channelId;
 
-    public Message(UUID userId, UUID channelId) {
-        super();
+    public Message(String text, UUID userId, UUID channelId, List<UUID> attachmentIds) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        this.updatedAt = createdAt;
+
+        this.text = text;
         this.userId = userId;
         this.channelId = channelId;
+        this.attachmentIds = attachmentIds;
     }
 
-    @Override
+    public void updateText(String text) {
+        this.text = text;
+        updatedAt = Instant.now();
+    }
+
     public String toString() {
-        return "[Message " +super.toString();
+        return "[Message : " + getText() + "]";
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class ReadStatus {
+
+    private UUID readStatusId;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private UUID userId;
+    private UUID channelId;
+    private Instant readAt;
+
+    public ReadStatus(UUID userId, UUID channelId,Instant readAt) {
+        this.readStatusId = UUID.randomUUID();
+        this.createdAt = Instant.now();
+
+        this.userId = userId;
+        this.channelId = channelId;
+        this.readAt = readAt;
+    }
+
+    public void updateReadAt(Instant readAt) {
+        this.readAt = readAt;
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -1,21 +1,55 @@
 package com.sprint.mission.discodeit.entity;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
 
-public class User extends CommonEntity implements Serializable {
+@Getter
+public class User implements Serializable {
     private static final long serialVersionUID = 1L;
-    private String username;
-    public User(String username) {
-        super();
-        this.username = username;
+
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private String userName;
+    private String email;
+    private String password;
+
+    @Setter
+    private UUID profileId;
+
+    public User(String userName, String email, String password) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+
+        this.userName = userName;
+        this.email = email;
+        this.password = password;
+        this.profileId = null;
 
     }
-    public String getUsername() {
-        return username;
+
+    public void updateUser(String userName, String email, String password, UUID profileId) {
+        if (userName != null) {
+            this.userName = userName;
+        }
+        if (email != null) {
+            this.email = email;
+        }
+        if (password != null) {
+            this.password = password;
+        }
+        if (profileId != null) {
+            this.profileId = profileId;
+        }
+        this.updatedAt = Instant.now();
     }
 
-    @Override
     public String toString() {
-        return "[ username: "+getUsername()+" USER "+super.toString();
+        return "[ userID: " + getId() + "userName: " + getUserName() + " ]";
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -1,0 +1,31 @@
+package com.sprint.mission.discodeit.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class UserStatus {
+    private UUID userStatusId;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private UUID userId;
+    private Instant lastActiveAt;
+
+
+    public UserStatus(UUID userId, Instant lastActiveAt) {
+        this.userStatusId = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        this.updatedAt = createdAt;
+
+        this.userId = userId;
+        this.lastActiveAt = lastActiveAt;
+    }
+
+    public boolean isOnline() {
+        return Instant.now().minusSeconds(300).isBefore(lastActiveAt);
+    }
+    public void updateLastActiveAt(Instant lastActiveAt){
+        this.lastActiveAt = lastActiveAt;
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BinaryContentRepository {
+
+    BinaryContent save (BinaryContent binaryContent);
+    BinaryContent findById(UUID id);
+    List<BinaryContent> findAll(List<UUID> ids);
+    void delete(UUID profileId);
+
+    void deleteAllById(List<UUID> attachmentIds);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
@@ -3,15 +3,18 @@ package com.sprint.mission.discodeit.repository;
 import com.sprint.mission.discodeit.entity.Channel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ChannelRepository {
-    void save(Channel channel);
-    Channel findById(UUID id);
-    void delete(UUID id);
-    void update(Channel channel);
+    Channel save(Channel channel);
+
+    Optional<Channel> findById(UUID channelId);
 
     List<Channel> findAll();
 
-    boolean existsById(UUID id);
+    boolean existsById(UUID channelId);
+
+    void delete(UUID channelId);
+
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -3,15 +3,21 @@ package com.sprint.mission.discodeit.repository;
 import com.sprint.mission.discodeit.entity.Message;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MessageRepository {
-    void save(Message message);
-    Message findById(UUID id);
-    void delete(UUID id);
-    void update(Message message);
+    Message save(Message message);
+
+    Optional<Message> findById(UUID messageId);
 
     List<Message> findAll();
 
-    boolean existsById(UUID id);
+    List<Message> findByChannelId(UUID channelId);
+
+    boolean existsById(UUID messageId);
+
+    void delete(UUID messageId);
+
+    void deleteByChannelId(UUID channelId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
@@ -1,0 +1,28 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.ReadStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ReadStatusRepository {
+    ReadStatus save(ReadStatus readStatus);
+
+    Optional<ReadStatus> findById(UUID readStatusId);
+
+    List<ReadStatus> findAllByUserId(UUID userId);
+
+    Optional<ReadStatus> findByUserIdAndChannelId(UUID userId, UUID channelId);
+
+    void deleteById(UUID readStatusId);
+
+    boolean existsById(UUID readStatusId);
+
+}
+/*@Override
+public List<ReadStatus> findByUserId(UUID userId) {
+    return readStatusList.stream()
+            .filter(readStatus -> readStatus.getUserId().equals(userId))
+            .toList();
+}*/

--- a/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
@@ -3,15 +3,22 @@ package com.sprint.mission.discodeit.repository;
 import com.sprint.mission.discodeit.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository {
 
-    void save(User user);
-    User findById(UUID id);
-    void delete(UUID id);
-    void update(User user);
+    User save(User user);
+
+    Optional<User> findById(UUID userId);
+
+    Optional<User> findByUserName(String userName);
+
+    Optional<User> findByEmail(String email);
+
     List<User> findAll();
-    boolean existsById(UUID id);
-    boolean existsByUsername(String username);
+
+    boolean existsById(UUID userId);
+
+    void delete(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/UserStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/UserStatusRepository.java
@@ -1,0 +1,22 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.UserStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserStatusRepository {
+    UserStatus saveUserStatus(UserStatus userStatus);
+
+    boolean isUserOnline(UUID userId);
+
+    Optional<UserStatus> findByUserId(UUID userId);
+
+    List<UserStatus> findAll();
+
+    boolean existsByUserId(UUID userId);
+
+    void delete(UUID userId);
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
@@ -2,78 +2,81 @@ package com.sprint.mission.discodeit.repository.file;
 
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
+import org.springframework.stereotype.Repository;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+
+@Repository
 public class FileChannelRepository implements ChannelRepository {
-    private static final Path directoryPath = Paths.get("data/channels");
-    private static FileChannelRepository instance = null;
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
 
-    public static synchronized FileChannelRepository getInstance() {
-        if (instance == null) {
-            instance = new FileChannelRepository();
-        }
-        return instance;
-    }
-
-    private FileChannelRepository() {
-        try {
-            Files.createDirectories(directoryPath);
-        } catch (IOException e) {
-            throw new RuntimeException("디렉토리를 생성할 수 없습니다: " + e.getMessage());
+    public FileChannelRepository() {
+        this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "file-data-map", Channel.class.getSimpleName());
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
-    // 파일 경로를 생성하는 메서드
     private Path getFilePath(UUID channelId) {
-        return directoryPath.resolve("channel-" + channelId + ".data");
+        return DIRECTORY.resolve("channel-" + channelId + EXTENSION);
     }
 
-    // 파일에서 Channel 객체를 읽어오는 메서드
-    private Channel loadChannel(Path filePath) {
-        try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(filePath))) {
-            return (Channel) ois.readObject();
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("채널 데이터 읽기 실패: " + filePath, e);
-        }
-    }
-
-    private void saveChannel(Channel channel) {
-        Path filePath = getFilePath(channel.getId());
-        try (ObjectOutputStream oos = new ObjectOutputStream(Files.newOutputStream(filePath))) {
+    public void serialize(Channel channel) {
+        Path path = getFilePath(channel.getId());
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
             oos.writeObject(channel);
         } catch (IOException e) {
-            throw new RuntimeException("채널 저장 실패: " + channel.getId(), e);
+            throw new RuntimeException("채널 데이터를 저장하는 중 오류 발생: " + path, e);
+        }
+    }
+
+    public Channel deserialize(Path path) {
+        try (
+                FileInputStream fis = new FileInputStream(path.toFile());
+                ObjectInputStream ois = new ObjectInputStream(fis)
+        ) {
+            return (Channel) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("채널 파일을 읽는 중 오류 발생: " + path, e);
         }
     }
 
     @Override
-    public void save(Channel channel) {
-        saveChannel(channel);
+    public Channel save(Channel channel) {
+        serialize(channel);
+        return channel;
     }
 
     @Override
-    public Channel findById(UUID id) {
-        Path filePath = getFilePath(id);
-        if (Files.exists(filePath)) {
-            return loadChannel(filePath);
+    public Optional<Channel> findById(UUID channelId) {
+        Path path = getFilePath(channelId);
+        if (Files.notExists(path)) {
+            return Optional.empty();
         }
-        return null;
+        return Optional.of(deserialize(path));
     }
 
     @Override
     public List<Channel> findAll() {
         try {
-            return Files.list(directoryPath)
-                    .filter(Files::isRegularFile)
-                    .map(this::loadChannel)
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> deserialize(path))
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException("채널 목록을 불러오는 중 오류 발생", e);
@@ -81,24 +84,19 @@ public class FileChannelRepository implements ChannelRepository {
     }
 
     @Override
-    public void delete(UUID id) {
-        Path filePath = getFilePath(id);
-        try {
-            Files.deleteIfExists(filePath);
-            System.out.println(id + " 채널 삭제 완료되었습니다.");
-        } catch (IOException e) {
-            throw new RuntimeException("채널 삭제 실패: " + id, e);
-        }
+    public boolean existsById(UUID channelId) {
+        return Files.exists(getFilePath(channelId));
     }
 
     @Override
-    public void update(Channel channel) {
-        channel.updateTime(System.currentTimeMillis());
-        saveChannel(channel);
-        System.out.println(channel.getId() + " 채널 업데이트 완료되었습니다.");
+    public void delete(UUID channelId) {
+        Path path = getFilePath(channelId);
+        try {
+            Files.delete(path);
+            System.out.println(channelId + " 채널 삭제 완료되었습니다.");
+        } catch (IOException e) {
+            throw new RuntimeException("채널 삭제 실패: " + channelId, e);
+        }
     }
-    @Override
-    public boolean existsById(UUID id) {
-        return Files.exists(getFilePath(id));
-    }
+
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
@@ -8,27 +8,20 @@ import java.util.*;
 public class JCFChannelRepository implements ChannelRepository {
 
     private final Map<UUID, Channel> channelData;
-    private static JCFChannelRepository instance = null;
 
-    public static JCFChannelRepository getInstance() {
-        if (instance == null) {
-            instance = new JCFChannelRepository();
-        }
-        return instance;
-    }
-
-    private JCFChannelRepository() {
+    public JCFChannelRepository() {
         this.channelData = new HashMap<>();
     }
 
     @Override
-    public void save(Channel channel) {
-        channelData.put(channel.getId(), channel);
+    public Channel save(Channel channel) {
+        this.channelData.put(channel.getId(), channel);
+        return channel;
     }
 
     @Override
-    public Channel findById(UUID id) {
-        return channelData.get(id);
+    public Optional<Channel> findById(UUID channelId) {
+        return Optional.ofNullable(this.channelData.get(channelId));
     }
 
     @Override
@@ -37,18 +30,12 @@ public class JCFChannelRepository implements ChannelRepository {
     }
 
     @Override
-    public void delete(UUID id) {
-        channelData.remove(id);
+    public boolean existsById(UUID channelId) {
+        return channelData.containsKey(channelId);
     }
 
     @Override
-    public void update(Channel channel) {
-        channel.updateTime(System.currentTimeMillis());
-        channelData.put(channel.getId(), channel);
-    }
-
-    @Override
-    public boolean existsById(UUID id) {
-       return channelData.containsKey(id);
+    public void delete(UUID channelId) {
+        this.channelData.remove(channelId);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
@@ -8,27 +8,20 @@ import java.util.*;
 public class JCFMessageRepository implements MessageRepository {
 
     private final Map<UUID, Message> messageData;
-    private static JCFMessageRepository instance = null;
 
-    public static JCFMessageRepository getInstance() {
-        if (instance == null) {
-            instance = new JCFMessageRepository();
-        }
-        return instance;
-    }
-
-    private JCFMessageRepository() {
+    public JCFMessageRepository() {
         this.messageData = new HashMap<>();
     }
 
     @Override
-    public void save(Message message) {
+    public Message save(Message message) {
         messageData.put(message.getId(), message);
+        return message;
     }
 
     @Override
-    public Message findById(UUID id) {
-        return messageData.get(id);
+    public Optional<Message> findById(UUID messageId) {
+        return Optional.ofNullable(messageData.get(messageId));
     }
 
     @Override
@@ -37,19 +30,12 @@ public class JCFMessageRepository implements MessageRepository {
     }
 
     @Override
-    public void delete(UUID id) {
-        messageData.remove(id);
+    public boolean existsById(UUID messageId) {
+        return messageData.containsKey(messageId);
     }
 
     @Override
-    public void update(Message message) {
-        // 시간 갱신 (혹은 다른 필드 변경 시 필요한 로직)
-        message.updateTime(System.currentTimeMillis());
-        messageData.put(message.getId(), message);  // 변경된 데이터를 다시 저장
-    }
-
-    @Override
-    public boolean existsById(UUID id) {
-        return messageData.containsKey(id);
+    public void delete(UUID messageId) {
+        this.messageData.remove(messageId);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
@@ -7,54 +7,50 @@ import java.util.*;
 
 public class JCFUserRepository implements UserRepository {
 
-    private final Map<UUID,User> userdata;
-    private static JCFUserRepository instance = null;
+    private final Map<UUID, User> userData;
 
-    public static JCFUserRepository getInstance() {
-        if (instance == null) {
-            instance = new JCFUserRepository();
-        }
-        return instance;
-    }
-
-    private JCFUserRepository() {
-        this.userdata=new HashMap<>();
+    public JCFUserRepository() {
+        this.userData = new HashMap<>();
     }
 
     @Override
-    public void save(User user) {
-        userdata.put(user.getId(), user);
+    public User save(User user) {
+        userData.put(user.getId(), user);
+        return user;
     }
 
     @Override
-    public User findById(UUID id) {
-        return userdata.get(id);
+    public Optional<User> findById(UUID userId) {
+        return Optional.ofNullable(this.userData.get(userId));
+    }
+
+    @Override
+    public Optional<User> findByUserName(String userName) {
+        return userData.values().stream()
+                .filter(user -> user.getUserName().equals(userName)) // username 비교
+                .findFirst();
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userData.values().stream()
+                .filter(user -> user.getEmail().equals(email)) // email 비교
+                .findFirst();
     }
 
     @Override
     public List<User> findAll() {
-        return new ArrayList<>(userdata.values());
+        return new ArrayList<>(userData.values());
+    }
+
+
+    @Override
+    public boolean existsById(UUID userId) {
+        return userData.containsKey(userId);
     }
 
     @Override
-    public void delete(UUID id) {
-        userdata.remove(id);
-    }
-
-    @Override
-    public void update(User user) {
-        user.updateTime(System.currentTimeMillis());
-        userdata.put(user.getId(), user);
-    }
-
-    @Override
-    public boolean existsById(UUID id) {
-        return userdata.containsKey(id);
-    }
-
-    @Override
-    public boolean existsByUsername(String username) {
-        return userdata.values().stream()
-                .anyMatch(user -> user.getUsername().equals(username));
+    public void delete(UUID userId) {
+        this.userData.remove(userId);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/AuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.user.LoginRequestDTO;
+import com.sprint.mission.discodeit.dto.user.UserResponseDTO;
+
+public interface AuthService {
+    UserResponseDTO login(LoginRequestDTO dto);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/BinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/BinaryContentService.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentDTO;
+import com.sprint.mission.discodeit.entity.BinaryContent;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BinaryContentService {
+    BinaryContent create(BinaryContentDTO dto);
+    BinaryContent find(UUID binaryContentId);
+    List<BinaryContent> findAllByIdIn(List<UUID> binaryContentIds);
+    void delete(UUID binaryContentId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -1,15 +1,24 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.channel.ChannelResponseDTO;
+import com.sprint.mission.discodeit.dto.channel.CreatePrivateChannelDTO;
+import com.sprint.mission.discodeit.dto.channel.CreatePublicChannelDTO;
+import com.sprint.mission.discodeit.dto.channel.UpdateChannelDTO;
+import com.sprint.mission.discodeit.entity.Channel;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface ChannelService {
-    UUID createChannel();
+    Channel createPrivateChannel(CreatePrivateChannelDTO dto);
 
-    void searchChannel(UUID id);
+    Channel createPublicChannel(CreatePublicChannelDTO dto);
 
-    void searchAllChannels();
+    ChannelResponseDTO searchChannel(UUID channelId);
 
-    void updateChannel(UUID id);
+    List<ChannelResponseDTO> searchAllByUserId(UUID userId);
 
-    void deleteChannel(UUID id);
+    Channel updateChannel(UpdateChannelDTO dto);
+
+    void deleteChannel(UUID channelId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
@@ -1,15 +1,20 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.message.CreateMessageDTO;
+import com.sprint.mission.discodeit.dto.message.UpdateMessageDTO;
+import com.sprint.mission.discodeit.entity.Message;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface MessageService {
-    UUID createMessage(UUID userId, UUID channelId);
+    Message createMessage(CreateMessageDTO dto);
 
-    void searchMessage(UUID id);
+    Message searchMessage(UUID messageId);
 
-    void searchAllMessages();
+    List<Message> searchAllByChannelId(UUID channelId);
 
-    void updateMessage(UUID id);
+    Message updateMessage(UpdateMessageDTO dto);
 
-    void deleteMessage(UUID id);
+    void deleteMessage(UUID messageId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
@@ -1,0 +1,20 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.readStatus.CreateReadStatusDTO;
+import com.sprint.mission.discodeit.dto.readStatus.UpdateReadStatusDTO;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ReadStatusService {
+    ReadStatus create(CreateReadStatusDTO dto);
+
+    ReadStatus findById(UUID readStatusId);
+
+    List<ReadStatus> findAllByUserId(UUID userId);
+
+    ReadStatus update(UpdateReadStatusDTO dto);
+
+    void delete(UUID readStatusId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -1,15 +1,21 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.user.CreateUserDTO;
+import com.sprint.mission.discodeit.dto.user.UpdateUserDTO;
+import com.sprint.mission.discodeit.dto.user.UserResponseDTO;
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface UserService {
-    UUID createUser(String username);
+    User createUser(CreateUserDTO dto);
 
-    void searchUser(UUID id);
+    UserResponseDTO searchUser(UUID userId);
 
-    void searchAllUsers();
+    List<UserResponseDTO> searchAllUsers();
 
-    void updateUser(UUID id);
+    User updateUser(UpdateUserDTO dto);
 
-    void deleteUser(UUID id);
+    void deleteUser(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
@@ -1,0 +1,22 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.userStatus.CreateUserStatusDTO;
+import com.sprint.mission.discodeit.dto.userStatus.UpdateUserStatusDTO;
+import com.sprint.mission.discodeit.entity.UserStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserStatusService {
+    UserStatus createUserStatus(CreateUserStatusDTO dto);
+
+    UserStatus findById(UUID userId);
+
+    List<UserStatus> findAll();
+
+    UserStatus updateUserStatus(UpdateUserStatusDTO dto);
+
+    UserStatus updateByUserId(UUID userId, UpdateUserStatusDTO dto);
+
+    void deleteUserStatus(UUID userId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.user.LoginRequestDTO;
+import com.sprint.mission.discodeit.dto.user.UserResponseDTO;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BasicAuthService implements AuthService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResponseDTO login(LoginRequestDTO dto) {
+        User user = userRepository.findByUserName(dto.userName())
+                .filter(u -> u.getPassword().equals(dto.password()))
+                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
+
+        return new UserResponseDTO(
+                user.getId(),
+                user.getCreatedAt(),
+                user.getUpdatedAt(),
+                user.getUserName(),
+                user.getEmail(),
+                user.getProfileId(),
+                true
+        );
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -1,0 +1,39 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentDTO;
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
+import com.sprint.mission.discodeit.service.BinaryContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BasicBinaryContentService implements BinaryContentService {
+
+    private final BinaryContentRepository binaryContentRepository;
+
+    @Override
+    public BinaryContent create(BinaryContentDTO dto) {
+        BinaryContent binaryContent = new BinaryContent();
+        return binaryContent;
+    }
+
+    @Override
+    public BinaryContent find(UUID binaryContentId) {
+        return binaryContentRepository.findById(binaryContentId);
+    }
+
+    @Override
+    public List<BinaryContent> findAllByIdIn(List<UUID> binaryContentIds) {
+        return binaryContentRepository.findAll(binaryContentIds);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        binaryContentRepository.delete(id);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -1,0 +1,67 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.readStatus.CreateReadStatusDTO;
+import com.sprint.mission.discodeit.dto.readStatus.UpdateReadStatusDTO;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.ReadStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BasicReadStatusService implements ReadStatusService {
+    private final ReadStatusRepository readStatusRepository;
+    private final UserRepository userRepository;
+    private final ChannelRepository channelRepository;
+
+    @Override
+    public ReadStatus create(CreateReadStatusDTO dto) {
+        User user = userRepository.findById(dto.userId())
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        Channel channel = channelRepository.findById(dto.channelId())
+                .orElseThrow(() -> new NoSuchElementException("채널을 찾을 수 없습니다."));
+
+        if (readStatusRepository.findByUserIdAndChannelId(dto.userId(), dto.channelId()).isPresent()) {
+            throw new IllegalArgumentException("ReadStatus가 이미 존재합니다.");
+        }
+
+        ReadStatus readStatus = new ReadStatus(dto.userId(), dto.channelId(), dto.readAt());
+        return readStatusRepository.save(readStatus);
+    }
+
+    @Override
+    public ReadStatus findById(UUID readStatusId) {
+        return readStatusRepository.findById(readStatusId)
+                .orElseThrow(() -> new NoSuchElementException("읽은 상태를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public List<ReadStatus> findAllByUserId(UUID userId) {
+        return readStatusRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public ReadStatus update(UpdateReadStatusDTO dto) {
+        ReadStatus readStatus = readStatusRepository.findById(dto.readStatusId())
+                .orElseThrow(() -> new NoSuchElementException("ReadStatus를 찾을 수 없습니다."));
+        readStatus.updateReadAt(dto.readAt());
+    }
+
+    @Override
+    public void delete(UUID readStatusId) {
+        if (!readStatusRepository.existsById(readStatusId)) {
+            throw new NoSuchElementException("ReadStatus를 찾을 수 없습니다.");
+        }
+        readStatusRepository.deleteById(readStatusId);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
@@ -1,0 +1,71 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.userStatus.CreateUserStatusDTO;
+import com.sprint.mission.discodeit.dto.userStatus.UpdateUserStatusDTO;
+import com.sprint.mission.discodeit.entity.UserStatus;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.UserStatusRepository;
+import com.sprint.mission.discodeit.service.UserStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BasicUserStatusService implements UserStatusService {
+    private final UserStatusRepository userStatusRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public UserStatus createUserStatus(CreateUserStatusDTO dto) {
+        if (!userRepository.existsById(dto.userId())) {
+            throw new NoSuchElementException("존재하지 않는 사용자입니다.");
+        }
+
+        if (userStatusRepository.existsByUserId(dto.userId())) {
+            throw new IllegalStateException("이미 존재하는 사용자 상태입니다.");
+        }
+
+        UserStatus userStatus = new UserStatus(dto.userId(), dto.lastActiveAt());
+        return userStatusRepository.saveUserStatus(userStatus);
+    }
+
+    @Override
+    public UserStatus findById(UUID userId) {
+        return userStatusRepository.findByUserId(userId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 상태 ID입니다."));
+    }
+
+    @Override
+    public List<UserStatus> findAll() {
+        return userStatusRepository.findAll();
+    }
+
+    @Override
+    public UserStatus updateUserStatus(UpdateUserStatusDTO dto) {
+        UserStatus userStatus = findById(dto.userId());
+
+        userStatus.updateLastActiveAt(dto.lastActiveAt());
+        return userStatusRepository.saveUserStatus(userStatus);
+    }
+
+    @Override
+    public UserStatus updateByUserId(UUID userId, UpdateUserStatusDTO dto) {
+        UserStatus userStatus = userStatusRepository.findByUserId(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 사용자의 상태가 없습니다."));
+
+        userStatus.updateLastActiveAt(dto.lastActiveAt());
+        return userStatusRepository.saveUserStatus(userStatus);
+    }
+
+    @Override
+    public void deleteUserStatus(UUID userId) {
+        if (!userStatusRepository.existsByUserId(userId)) {
+            throw new NoSuchElementException("존재하지 않는 상태 ID입니다.");
+        }
+        userStatusRepository.delete(userId);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileChannelService.java
@@ -1,110 +1,130 @@
 package com.sprint.mission.discodeit.service.file;
 
 import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.service.ChannelService;
 
 import java.io.*;
 import java.nio.file.*;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 public class FileChannelService implements ChannelService {
-    private static final Path directoryPath = Paths.get("data/channels");
-    private static FileChannelService instance = null;
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
 
-    public static synchronized FileChannelService getInstance() {
-        if (instance == null) {
-            instance = new FileChannelService();
-        }
-        return instance;
-    }
-
-    private FileChannelService() {
-        try {
-            Files.createDirectories(directoryPath);
-        } catch (IOException e) {
-            throw new RuntimeException("디렉토리를 생성할 수 없습니다: " + e.getMessage());
-        }
-    }
-
-    @Override
-    public UUID createChannel() {
-        Channel channel = new Channel();
-        saveChannel(channel);
-        System.out.println("채널이 생성되었습니다: \n" + channel);
-        return channel.getId();
-    }
-
-    public void saveChannel(Channel channel) {
-        Path filePath = getFilePath(channel.getId());
-        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(filePath.toFile()))) {
-            oos.writeObject(channel);
-        } catch (IOException e) {
-            throw new RuntimeException("채널 저장 실패: " + channel.getId(), e);
-        }
-    }
-
-    public Channel loadChannel(Path filePath) {
-        try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(filePath))) {
-            return (Channel) ois.readObject();
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("채널 데이터 읽기 실패: " + filePath, e);
+    public FileChannelService() {
+        this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "file-data-map", User.class.getSimpleName());
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
     public Path getFilePath(UUID channelId) {
-        return directoryPath.resolve("channel-" + channelId + ".data");
+        return DIRECTORY.resolve("channel-" + channelId + ".data");
     }
 
-    @Override
-    public void searchChannel(UUID id) {
-        Path filePath = getFilePath(id);
-        if (!Files.exists(filePath)) {
-            System.out.println("조회하신 채널이 존재하지 않습니다.");
-            return;
-        }
-        Channel channel = loadChannel(filePath);
-        System.out.println("CHANNEL: " + channel);
-    }
-
-    @Override
-    public void searchAllChannels() {
-        try {
-            Files.list(directoryPath)
-                    .filter(Files::isRegularFile)
-                    .forEach(path -> {
-                        Channel channel = loadChannel(path);
-                        System.out.println("CHANNEL: " + channel);
-                    });
+    private void serializeChannel(Channel channel, Path path) {
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
+            oos.writeObject(channel);
         } catch (IOException e) {
-            throw new RuntimeException("채널 목록 읽기 실패: " + e);
+            throw new RuntimeException("사용자 데이터를 저장하는 중 오류 발생: " + path, e);
         }
     }
 
-    @Override
-    public void updateChannel(UUID id) {
-        Path filePath = getFilePath(id);
-        if (!Files.exists(filePath)) {
-            System.out.println("업데이트할 채널이 존재하지 않습니다.");
-            return;
+    private Channel deserializeChannel(Path path) {
+        try (
+                FileInputStream fis = new FileInputStream(path.toFile());
+                ObjectInputStream ois = new ObjectInputStream(fis)
+        ) {
+            return (Channel) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("사용자 파일을 읽는 중 오류 발생: " + path, e);
         }
-        Channel channel = loadChannel(filePath);
-        channel.updateTime(System.currentTimeMillis());
-        saveChannel(channel);
-        System.out.println(id + " 채널 업데이트 완료되었습니다.");
+    }
+
+
+    @Override
+    public Channel createChannel(ChannelType type, String channelName, String description) {
+        Channel channel = new Channel(type, channelName, description);
+        serializeChannel(channel, getFilePath(channel.getId()));
+        System.out.println("채널이 생성되었습니다: \n" + channel);
+        return channel;
     }
 
     @Override
-    public void deleteChannel(UUID id) {
-        Path filePath = getFilePath(id);
+    public Channel searchChannel(UUID channelId) {
+        return deserializeChannel(getFilePath(channelId));
+    }
+
+    @Override
+    public List<Channel> searchAllChannels() {
         try {
-            Files.deleteIfExists(filePath);
-            System.out.println(id + " 채널 삭제 완료되었습니다.");
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> deserializeChannel(path))
+                    .toList();
         } catch (IOException e) {
-            throw new RuntimeException("채널 삭제 실패: " + id, e);
+            throw new RuntimeException(e);
         }
     }
 
-    public boolean existChannel(UUID id) {
-        return Files.exists(getFilePath(id));
+    @Override
+    public Channel updateAll(UUID channelId, String channelName, String description) {
+        existChannel(channelId);
+        Path path = getFilePath(channelId);
+        Channel channel = deserializeChannel(path);
+        channel.updateAll(channelName, description);
+        serializeChannel(channel, path);
+        return channel;
+    }
+
+    @Override
+    public Channel updateChannelName(UUID channelId, String channelName) {
+        existChannel(channelId);
+        Path path = getFilePath(channelId);
+        Channel channel = deserializeChannel(path);
+        channel.updateChannelName(channelName);
+        serializeChannel(channel, path);
+        return channel;
+    }
+
+    @Override
+    public Channel updateChannelDescription(UUID channelId, String description) {
+        existChannel(channelId);
+        Path path = getFilePath(channelId);
+        Channel channel = deserializeChannel(path);
+        channel.updateChannelDescription(description);
+        serializeChannel(channel, path);
+        return channel;
+    }
+
+    @Override
+    public void deleteChannel(UUID channelId) {
+        Path path = getFilePath(channelId);
+        try {
+            existChannel(channelId);
+            Files.delete(path);
+            System.out.println(channelId + " 채널 삭제 완료되었습니다.");
+        } catch (IOException e) {
+            throw new RuntimeException("채널 삭제 실패: " + channelId, e);
+        }
+    }
+
+    public boolean existChannel(UUID channelId) {
+        Path path = getFilePath(channelId);
+        if (!Files.exists(path)) {
+            throw new NoSuchElementException("채널이 존재하지 않습니다." + channelId);
+        }
+        return true;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileMessageService.java
@@ -1,121 +1,126 @@
 package com.sprint.mission.discodeit.service.file;
 
 import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
 
 import java.io.*;
 import java.nio.file.*;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 public class FileMessageService implements MessageService {
-    private static FileMessageService instance;
-    private static final Path directoryPath = Paths.get("data/messages");
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
 
-    private FileUserService userservice;
-    private FileChannelService channelservice;
+    private final UserService userService;
+    private final ChannelService channelService;
 
-    public static synchronized FileMessageService getInstance(FileUserService userService, FileChannelService channelService) {
-        if (instance == null) {
-            instance = new FileMessageService(userService, channelService);
+    public FileMessageService(UserService userService, ChannelService channelService) {
+        this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "file-data-map", Message.class.getSimpleName()).toAbsolutePath();
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
-        return instance;
-    }
-
-    private FileMessageService(FileUserService userservice, FileChannelService channelservice) {
-        this.userservice = userservice;
-        this.channelservice = channelservice;
-        try {
-            Files.createDirectories(directoryPath);
-        } catch (IOException e) {
-            throw new RuntimeException("디렉토리를 생성할 수 없습니다: " + e.getMessage());
-        }
-    }
-
-    @Override
-    public UUID createMessage(UUID userId, UUID channelId) {
-        if (!userservice.existUser(userId)) {
-            throw new IllegalArgumentException("존재하지 않는 사용자 입니다. 메세지를 생성할 수 없습니다.");
-        }
-        if (!channelservice.existChannel(channelId)) {
-            throw new IllegalArgumentException("존재하지 않는 채널 입니다. 메세지를 생성할 수 없습니다.");
-        }
-        Message message = new Message(userId, channelId);
-        saveMessage(message);
-        System.out.println("메세지가 생성되었습니다: \n" + message);
-        return message.getId();
-    }
-
-    public void saveMessage(Message message) {
-        Path filePath = getFilePath(message.getId());
-        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(filePath.toFile()))) {
-            oos.writeObject(message);
-        } catch (IOException e) {
-            throw new RuntimeException("메세지 저장 실패: " + message.getId(), e);
-        }
-    }
-
-    public Message loadMessage(Path filePath) {
-        try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(filePath))) {
-            return (Message) ois.readObject();
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("메세지 데이터 읽기 실패: " + filePath, e);
-        }
+        this.userService = userService;
+        this.channelService = channelService;
     }
 
     public Path getFilePath(UUID messageId) {
-        return directoryPath.resolve("message-" + messageId + ".data");
+        return DIRECTORY.resolve("message-" + messageId + EXTENSION);
     }
 
-    @Override
-    public void searchMessage(UUID id) {
-        Path filePath = getFilePath(id);
-        if (!Files.exists(filePath)) {
-            System.out.println("조회하신 메세지가 존재하지 않습니다.");
-            return;
-        }
-        Message message = loadMessage(filePath);
-        System.out.println("MESSAGE: " + message);
-    }
-
-    @Override
-    public void searchAllMessages() {
-        try {
-            Files.list(directoryPath)
-                    .filter(Files::isRegularFile)
-                    .forEach(path -> {
-                        Message message = loadMessage(path);
-                        System.out.println("MESSAGE: " + message);
-                    });
+    private void serializeMessage(Message message, Path path) {
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
+            oos.writeObject(message);
         } catch (IOException e) {
-            throw new RuntimeException("메세지 목록 읽기 실패: " + e);
+            throw new RuntimeException("사용자 데이터를 저장하는 중 오류 발생: " + path, e);
+        }
+    }
+
+    private Message deserialMessage(Path path) {
+        try (
+                FileInputStream fis = new FileInputStream(path.toFile());
+                ObjectInputStream ois = new ObjectInputStream(fis)
+        ) {
+            return (Message) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("사용자 파일을 읽는 중 오류 발생: " + path, e);
         }
     }
 
     @Override
-    public void updateMessage(UUID id) {
-        Path filePath = getFilePath(id);
-        if (!Files.exists(filePath)) {
-            System.out.println("업데이트할 메세지가 존재하지 않습니다.");
-            return;
-        }
-        Message message = loadMessage(filePath);
-        message.updateTime(System.currentTimeMillis());
-        saveMessage(message);
-        System.out.println(id + " 메세지 업데이트 완료되었습니다.");
-    }
-
-    @Override
-    public void deleteMessage(UUID id) {
-        Path filePath = getFilePath(id);
+    public Message createMessage(String text, UUID userId, UUID channelId) {
         try {
-            Files.deleteIfExists(filePath);
-            System.out.println(id + " 메세지 삭제 완료되었습니다.");
+            userService.searchUser(userId);
+        } catch (Exception e) {
+            throw new NoSuchElementException("존재하지 않는 사용자 입니다. 메세지를 생성할 수 없습니다.");
+        }
+
+        try {
+            channelService.searchChannel(channelId);
+        } catch (Exception e) {
+            throw new NoSuchElementException("존재하지 않는 채널 입니다. 메세지를 생성할 수 없습니다.");
+        }
+        Message message = new Message(text, userId, channelId);
+        serializeMessage(message, getFilePath(message.getId()));
+        System.out.println("메세지가 생성되었습니다: \n" + message);
+        return message;
+    }
+
+    @Override
+    public Message searchMessage(UUID messageId) {
+        return deserialMessage(getFilePath(messageId));
+    }
+
+    @Override
+    public List<Message> searchAllMessages() {
+        try {
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> deserialMessage(path))
+                    .toList();
         } catch (IOException e) {
-            throw new RuntimeException("메세지 삭제 실패: " + id, e);
+            throw new RuntimeException(e);
         }
     }
 
-    public boolean existMessage(UUID id) {
-        return Files.exists(getFilePath(id));
+    @Override
+    public Message updateMessage(UUID messageId, String text) {
+        existMessage(messageId);
+        Path path = getFilePath(messageId);
+        Message message = deserialMessage(path);
+        message.updateText(text);
+
+        serializeMessage(message, path);
+        return message;
+    }
+
+    @Override
+    public void deleteMessage(UUID messageId) {
+        existMessage(messageId);
+        Path path = getFilePath(messageId);
+        try {
+            Files.delete(path);
+            System.out.println(messageId + " 메세지 삭제 완료되었습니다.");
+        } catch (IOException e) {
+            throw new RuntimeException("메세지 삭제 실패: " + messageId, e);
+        }
+    }
+
+    public boolean existMessage(UUID messageId) {
+        Path path = getFilePath(messageId);
+        if (!Files.exists(path)) {
+            throw new NoSuchElementException("메세지가 존재하지 않습니다.");
+        }
+        return true;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFChannelService.java
@@ -1,78 +1,83 @@
 package com.sprint.mission.discodeit.service.jcf;
 
 import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
 import com.sprint.mission.discodeit.service.ChannelService;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public class JCFChannelService implements ChannelService {
     private final Map<UUID, Channel> data;
-    private static JCFChannelService instance = null;
 
-    public static JCFChannelService getInstance() {
-        if (instance == null) {
-            instance = new JCFChannelService();
-        }
-        return instance;
-    }
-
-    private JCFChannelService() {
+    public JCFChannelService() {
         this.data = new HashMap<>();
     }
 
     @Override
-    public UUID createChannel() {
-        Channel channel = new Channel();
+    public Channel createChannel(ChannelType type, String channelName, String description) {
+        Channel channel = new Channel(type, channelName, description);
         data.put(channel.getId(), channel);
         System.out.println("채널이 생성되었습니다: \n" + channel);
-        return channel.getId();
+        return channel;
     }
 
     @Override
-    public void searchChannel(UUID id) {
-        if (!data.containsKey(id)) {
-            System.out.println("조회하신 채널이 존재하지 않습니다.");
-            return;
-        }
-        System.out.println("CHANNEL: " + data.get(id));
-
+    public Channel searchChannel(UUID channelId) {
+        Channel channel = findChannel(channelId);
+        System.out.println("CHANNEL: " + channel);
+        return channel;
     }
 
+
     @Override
-    public void searchAllChannels() {
+    public List<Channel> searchAllChannels() {
         if (data.isEmpty()) {
-            System.out.println("등록된 채널이 존재하지 않습니다.");
-            return;
+            throw new NoSuchElementException("등록된 채널이 존재하지 않습니다.");
         }
-        for (Channel channel : data.values()) {
+        List<Channel> channels = new ArrayList<>(data.values());
+        for (Channel channel : channels) {
             System.out.println("CHANNEL: " + channel);
         }
+        return channels;
     }
 
     @Override
-    public void updateChannel(UUID id) {
-        if (!data.containsKey(id)) {
-            System.out.println("업데이트할 채널이 존재하지 않습니다.");
-            return;
-        }
-        data.get(id).updateTime(System.currentTimeMillis());
-        System.out.println(id + " 채널 업데이트 완료되었습니다.");
+    public Channel updateAll(UUID channelId, String channelName, String description) {
+        Channel channel = findChannel(channelId);
+        channel.updateAll(channelName, description);
+        System.out.println(channelId + " 채널 업데이트 완료되었습니다.");
+        return channel;
+    }
+
+    @Override
+    public Channel updateChannelName(UUID channelId, String channelName) {
+        Channel channel = findChannel(channelId);
+        channel.updateChannelName(channelName);
+        System.out.println(channelId + " 채널 이름이 업데이트 완료되었습니다.");
+        return channel;
 
     }
 
     @Override
-    public void deleteChannel(UUID id) {
-        if (!data.containsKey(id)) {
-            System.out.println("삭제할 채널이 존재하지 않습니다.");
-            return;
-        }
-        data.remove(id);
-        System.out.println(id + " 채널 삭제 완료되었습니다.");
-
+    public Channel updateChannelDescription(UUID channelId, String description) {
+        Channel channel = findChannel(channelId);
+        channel.updateChannelDescription(description);
+        System.out.println(channelId + " 채널 설명이 업데이트 완료되었습니다.");
+        return channel;
     }
-    public boolean existChannel(UUID id) {
-        return data.containsKey(id);
+
+    @Override
+    public void deleteChannel(UUID channelId) {
+        findChannel(channelId);
+        data.remove(channelId);
+        System.out.println(channelId + " 채널 삭제 완료되었습니다.");
+    }
+
+    public Channel findChannel(UUID channelId) {
+        Channel channel = data.get(channelId);
+        if (channel == null) {
+            throw new NoSuchElementException("해당 채널이 존재하지 않습니다.");
+        }
+        return channel;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFUserService.java
@@ -3,76 +3,88 @@ package com.sprint.mission.discodeit.service.jcf;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.service.UserService;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public class JCFUserService implements UserService {
     private final Map<UUID, User> data;
-    private static JCFUserService instance = null;
 
-    public static JCFUserService getInstance() {
-        if (instance == null) {
-            instance = new JCFUserService();
-        }
-        return instance;
-    }
-
-    private JCFUserService() {
+    public JCFUserService() {
         this.data = new HashMap<>();
     }
 
     @Override
-    public UUID createUser(String username) {
-        User user = new User(username);
+    public User createUser(String userName, String email, String password) {
+        User user = new User(userName, email, password);
         data.put(user.getId(), user);
         System.out.println("사용자가 생성되었습니다: \n" + user);
-        return user.getId();
+        return user;
     }
 
     @Override
-    public void searchUser(UUID id) {
-        if (!data.containsKey(id)) {
-            System.out.println("조회하신 사용자가 존재하지 않습니다.");
-            return;
-        }
-        System.out.println("USER: " + data.get(id));
-
+    public User searchUser(UUID userId) {
+        User user = findUser(userId);
+        System.out.println("USER: " + user);
+        return user;
     }
 
     @Override
-    public void searchAllUsers() {
+    public List<User> searchAllUsers() {
         if (data.isEmpty()) {
-            System.out.println("등록된 사용자가 존재하지 않습니다.");
-            return;
+            throw new NoSuchElementException("등록된 사용자가 존재하지 않습니다.");
         }
-        for (User user : data.values()) {
+        List<User> users = new ArrayList<>(data.values());
+        for (User user : users) {
             System.out.println("USER: " + user);
         }
-    }
-
-    @Override
-    public void updateUser(UUID id) {
-        if (!data.containsKey(id)) {
-            System.out.println("업데이트할 사용자가 존재하지 않습니다.");
-            return;
-        }
-        data.get(id).updateTime(System.currentTimeMillis());
-        System.out.println(id + " 사용자 업데이트 완료되었습니다.");
+        return users;
 
     }
 
     @Override
-    public void deleteUser(UUID id) {
-        if (!data.containsKey(id)) {
-            System.out.println("삭제할 사용자가 존재하지 않습니다.");
-            return;
-        }
-        data.remove(id);
-        System.out.println(id + " 사용자 삭제 완료되었습니다.");
+    public User updateAll(UUID userId, String userName, String email, String password) {
+        User user = findUser(userId);
+        user.updateAll(userName, email, password);
+        System.out.println(userId + " 사용자 업데이트 완료되었습니다.");
+        return user;
+    }
+
+    @Override
+    public User updateUserName(UUID userId, String userName) {
+        User user = findUser(userId);
+        user.updateUserName(userName);
+        System.out.println(userId + " 사용자 이름이 업데이트 완료되었습니다.");
+        return user;
+    }
+
+    @Override
+    public User updateEmail(UUID userId, String email) {
+        User user = findUser(userId);
+        user.updateEmail(email);
+        System.out.println(userId + " 사용자 이메일이 업데이트 완료되었습니다.");
+        return user;
+    }
+
+    @Override
+    public User updatePassword(UUID userId, String password) {
+        User user = findUser(userId);
+        user.updatePassword(password);
+        System.out.println(userId + " 사용자 비밀번호가 업데이트 완료되었습니다.");
+        return user;
+    }
+
+    @Override
+    public void deleteUser(UUID userId) {
+        findUser(userId);
+        data.remove(userId);
+        System.out.println(userId + " 사용자 삭제 완료되었습니다.");
 
     }
-    public boolean existUser(UUID id){
-        return data.containsKey(id);
+
+    public User findUser(UUID userId) {
+        User user = data.get(userId);
+        if (user == null) {
+            throw new NoSuchElementException("해당 사용자가 존재하지 않습니다.");
+        }
+        return user;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: discodeit
+
+server:
+  port: 8080
+
+logging:
+  level:
+    root: info

--- a/src/test/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/test/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,0 +1,13 @@
+package com.sprint.mission.discodeit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DiscodeitApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
## 요구사항

### 기본 요구사항
Spring 프로젝트 초기화
- [x] Spring Initializr를 통해 zip 파일을 다운로드하세요. 
- [x] 빌드 시스템은 Gradle - Groovy를 사용합니다.
- [x] 언어는 Java 17를 사용합니다.
- [x] Spring Boot의 버전은 3.4.0입니다.
- [x] GroupId는 com.sprint.mission입니다.
- [x] ArtifactId와 Name은 discodeit입니다.
- [x] packaging 형식은 Jar입니다
- [x] Dependency를 추가합니다.
- [x] Lombok
- [x] Spring Web
- [x] zip 파일을 압축해제하고 원래 진행 중이던 프로젝트에 붙여넣기하세요. 일부 파일은 덮어쓰기할 수 있습니다.
- [x] application.properties 파일을 yaml 형식으로 변경하세요.
- [x] DiscodeitApplication의 main 메서드를 실행하고 로그를 확인해보세요.

Bean 선언 및 테스트
- [x] File*Repository 구현체를 Repository 인터페이스의 Bean으로 등록하세요.
- [x] Basic*Service 구현체를 Service 인터페이스의 Bean으로 등록하세요.
- [x] JavaApplication에서 테스트했던 코드를 DiscodeitApplication에서 테스트해보세요.
- [ ]  JavaApplication 의 main 메소드를 제외한 모든 메소드를 DiscodeitApplication클래스로 복사하세요.
- [x]  JavaApplication의 main 메소드에서 Service를 초기화하는 코드를 Spring Context를 활용하여 대체하세요.
- [x]  JavaApplication의 main 메소드의 셋업, 테스트 부분의 코드를 DiscodeitApplication클래스로 복사하세요.
Spring 핵심 개념 이해하기
- [x] JavaApplication과 DiscodeitApplication에서 Service를 초기화하는 방식의 차이에 대해 다음의 키워드를 중심으로 정리해보세요.
JavaApplication과 DiscodeitApplication의 Service 초기화 방식 비교
1. IoC Container (제어의 역전, Inversion of Control)
JavaApplication에서는 개발자가 new 키워드를 사용하여 직접 객체를 생성하고 관리함.
DiscodeitApplication에서는 Spring IoC Container가 객체의 생성과 관리를 담당하며, SpringApplication.run()을 통해 컨테이너가 실행됨.
2. Dependency Injection (의존성 주입)
JavaApplication에서는 new BasicUserService(userRepository) 같은 방식으로 직접 의존성을 주입함.
DiscodeitApplication에서는 @Service, @Repository 등의 애너테이션을 활용하여 Bean으로 등록하고, @Autowired 또는 생성자 주입을 사용하여 자동으로 의존성을 해결함.
3. Bean
JavaApplication에서는 Bean 개념 없이 직접 객체를 생성하여 사용함.
DiscodeitApplication에서는 @Component, @Service, @Repository 등을 통해 Bean으로 등록하여 Spring IoC 컨테이너에서 관리하도록 함.

Lombok 적용
- [x] 도메인 모델의 getter 메소드를 @Getter로 대체해보세요.
- [x] Basic*Service의 생성자를 @RequiredArgsConstructor로 대체해보세요.

비즈니스 로직 고도화
시간 타입 변경하기
- [x] 시간을 다루는 필드의 타입은 Instant로 통일합니다.
기존에 사용하던 Long보다 가독성이 뛰어나며, 시간대(Time Zone) 변환과 정밀한 시간 연산이 가능해 확장성이 높습니다.
새로운 도메인 추가하기
- [x]  공통: 앞서 정의한 도메인 모델과 동일하게 공통 필드(id, createdAt, updatedAt)를 포함합니다.

- [x]  ReadStatus

사용자가 채널 별 마지막으로 메시지를 읽은 시간을 표현하는 도메인 모델입니다. 사용자별 각 채널에 읽지 않은 메시지를 확인하기 위해 활용합니다.
- [x]  UserStatus

사용자 별 마지막으로 확인된 접속 시간을 표현하는 도메인 모델입니다. 사용자의 온라인 상태를 확인하기 위해 활용합니다.
- [x] 마지막 접속 시간을 기준으로 현재 로그인한 유저로 판단할 수 있는 메소드를 정의하세요.
마지막 접속 시간이 현재 시간으로부터 5분 이내이면 현재 접속 중인 유저로 간주합니다.
- [x]  BinaryContent

이미지, 파일 등 바이너리 데이터를 표현하는 도메인 모델입니다. 사용자의 프로필 이미지, 메시지에 첨부된 파일을 저장하기 위해 활용합니다.
- [x] 수정 불가능한 도메인 모델로 간주합니다. 따라서 updatedAt 필드는 정의하지 않습니다.
- [x] User, Message 도메인 모델과의 의존 관계 방향성을 잘 고려하여 id 참조 필드를 추가하세요.
- [x]  각 도메인 모델 별 레포지토리 인터페이스를 선언하세요.

DTO 활용하기
UserService 고도화
고도화
create
- [x] 선택적으로 프로필 이미지를 같이 등록할 수 있습니다.
- [x] DTO를 활용해 파라미터를 그룹화합니다.
유저를 등록하기 위해 필요한 파라미터, 프로필 이미지를 등록하기 위해 필요한 파라미터 등
- [x] username과 email은 다른 유저와 같으면 안됩니다.
- [x] UserStatus를 같이 생성합니다.
find, findAll
- [x] 사용자의 온라인 상태 정보를 같이 포함하세요.
- [x] 패스워드 정보는 제외하세요.
update
- [x] 선택적으로 프로필 이미지를 대체할 수 있습니다.
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
delete
-[x] 관련된 도메인도 같이 삭제합니다.
BinaryContent(프로필), UserStatus
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

AuthService 구현
login
- [x] username, password과 일치하는 유저가 있는지 확인합니다.
- [x] 일치하는 유저가 있는 경우: 유저 정보 반환
- [x] 일치하는 유저가 없는 경우: 예외 발생
- [x] DTO를 활용해 파라미터를 그룹화합니다.
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

ChannelService 고도화
고도화
create
PRIVATE 채널과 PUBLIC 채널을 생성하는 메소드를 분리합니다.
- [x] 분리된 각각의 메소드를 DTO를 활용해 파라미터를 그룹화합니다.
PRIVATE 채널을 생성할 때:
- [x] 채널에 참여하는 User의 정보를 받아 User 별 ReadStatus 정보를 생성합니다.
- [x] name과 description 속성은 생략합니다.
PUBLIC 채널을 생성할 때에는 기존 로직을 유지합니다.
find
DTO를 활용하여:
- [x] 해당 채널의 가장 최근 메시지의 시간 정보를 포함합니다.
- [x] PRIVATE 채널인 경우 참여한 User의 id 정보를 포함합니다.
findAll
DTO를 활용하여:
- [x] 해당 채널의 가장 최근 메시지의 시간 정보를 포함합니다.
- [x] PRIVATE 채널인 경우 참여한 User의 id 정보를 포함합니다.
- [x] 특정 User가 볼 수 있는 Channel 목록을 조회하도록 조회 조건을 추가하고, 메소드 명을 변경합니다. findAllByUserId
- [x] PUBLIC 채널 목록은 전체 조회합니다.
- [x] PRIVATE 채널은 조회한 User가 참여한 채널만 조회합니다.
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
- [x] PRIVATE 채널은 수정할 수 없습니다.
delete
- [x] 관련된 도메인도 같이 삭제합니다.
Message, ReadStatus
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

MessageService 고도화
고도화
create
- [x] 선택적으로 여러 개의 첨부파일을 같이 등록할 수 있습니다.
- [x] DTO를 활용해 파라미터를 그룹화합니다.
findAll
- [x] 특정 Channel의 Message 목록을 조회하도록 조회 조건을 추가하고, 메소드 명을 변경합니다. findallByChannelId
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
delete
- [x] 관련된 도메인도 같이 삭제합니다.
첨부파일(BinaryContent)
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

ReadStatusService 구현
create
- [x] DTO를 활용해 파라미터를 그룹화합니다.
- [x] 관련된 Channel이나 User가 존재하지 않으면 예외를 발생시킵니다.
- [x] 같은 Channel과 User와 관련된 객체가 이미 존재하면 예외를 발생시킵니다.
find
- [x] id로 조회합니다.
findAllByUserId
- [x] userId를 조건으로 조회합니다.
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
delete
- [x] id로 삭제합니다.
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

UserStatusService 고도화
create
- [x] DTO를 활용해 파라미터를 그룹화합니다.
- [x] 관련된 User가 존재하지 않으면 예외를 발생시킵니다.
- [x] 같은 User와 관련된 객체가 이미 존재하면 예외를 발생시킵니다.
find
- [x] id로 조회합니다.
findAll
- [x] 모든 객체를 조회합니다.
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
updateByUserId
- [x] userId 로 특정 User의 객체를 업데이트합니다.
delete
- [x] id로 삭제합니다.
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

BinaryContentService 구현
create
- [x] DTO를 활용해 파라미터를 그룹화합니다.
find
- [x] id로 조회합니다.
findAllByIdIn
- [x] id 목록으로 조회합니다.
delete
- [x] id로 삭제합니다.
의존성
같은 레이어 간 의존성 주입은 순환 참조 방지를 위해 지양합니다. 다른 Service 대신 필요한 Repository 의존성을 주입해보세요.

새로운 도메인 Repository 구현체 구현
- [ ]  지금까지 인터페이스로 설계한 각각의 Repository를 JCF, File로 각각 구현하세요.

### 심화 요구사항
Bean 다루기
- [ ]  Repository 구현체 중에 어떤 구현체를 Bean으로 등록할지 Java 코드의 변경 없이 application.yaml 설정 값을 통해 제어해보세요.

# application.yaml
discodeit:
    repository: 
        type: jcf   # jcf | file
- [ ] discodeit.repository.type 설정값에 따라 Repository 구현체가 정해집니다.
- [ ] 값이 jcf 이거나 없으면 JCF*Repository 구현체가 Bean으로 등록되어야 합니다.
- [ ] 값이 file 이면 File*Repository 구현체가 Bean으로 등록되어야 합니다.
- [ ]  File*Repository 구현체의 파일을 저장할 디렉토리 경로를 application.yaml 설정 값을 통해 제어해보세요.

# application.yaml
discodeit:
    repository: 
        type: jcf   # jcf | file
        file-directory: .discodeit

## 멘토에게
- 새로운 도메인 Repository 구현체 구현은 아직 완성하지 못했습니다, 좀 더 공부한 후 진행하겠습니다!
- 코드를 여기저기 고치다보니, 연결된 곳이 많아 코드가 엉망이 되곤 하는데.. 역시 설계할 때 잘해야 하는걸까요..? 어떻게 해야 깔끔하게 코드를 짤 수 있을까요?

