### PR TITLE
[김현호] sprint4

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,20 +1,8 @@
 package com.sprint.mission.discodeit;
 
-import com.sprint.mission.discodeit.dto.request.message.MessageCreateRequest;
-import com.sprint.mission.discodeit.dto.request.channel.PublicChannelCreateRequest;
-import com.sprint.mission.discodeit.dto.request.user.UserCreateRequest;
-import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.entity.Message;
-import com.sprint.mission.discodeit.entity.User;
-import com.sprint.mission.discodeit.service.ChannelService;
-import com.sprint.mission.discodeit.service.MessageService;
-import com.sprint.mission.discodeit.service.UserService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-
-import java.util.ArrayList;
-import java.util.Optional;
 
 @SpringBootApplication
 public class DiscodeitApplication {

--- a/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.dto.request.user.LoginRequest;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.AuthService;
+import com.sprint.mission.discodeit.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+    private final UserService userService;
+
+    @GetMapping("/login")
+    public ResponseEntity<UserDto> userLogin(@RequestBody LoginRequest request) {
+        System.out.println("로그인 Api가 요청 됐습니다.");
+        User loginUser = authService.login(request);
+        UserDto userDto = userService.find(loginUser.getId());
+
+        return ResponseEntity.ok(userDto);
+    }
+}
+
+

--- a/src/main/java/com/sprint/mission/discodeit/controller/BinaryContentController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/BinaryContentController.java
@@ -1,0 +1,25 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.service.BinaryContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/binary")
+public class BinaryContentController {
+    private final BinaryContentService binaryContentService;
+
+    @GetMapping("/download")
+    public ResponseEntity<List<BinaryContent>> downloadBinaryList(@RequestParam List<UUID> binaryIds) {
+        System.out.println("바이너리 파일 조회 API 실행");
+        List<BinaryContent> binaryContentList = binaryContentService.findAllByIdIn(binaryIds);
+        System.out.println("binary list :" + binaryContentList);
+        return ResponseEntity.ok(binaryContentList);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/BinaryContentController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/BinaryContentController.java
@@ -11,15 +11,23 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/binary")
+@RequestMapping("/api/binaryContent")
 public class BinaryContentController {
     private final BinaryContentService binaryContentService;
 
     @GetMapping("/download")
     public ResponseEntity<List<BinaryContent>> downloadBinaryList(@RequestParam List<UUID> binaryIds) {
-        System.out.println("바이너리 파일 조회 API 실행");
+        System.out.println("바이너리 여러 파일 조회 API 실행");
         List<BinaryContent> binaryContentList = binaryContentService.findAllByIdIn(binaryIds);
         System.out.println("binary list :" + binaryContentList);
         return ResponseEntity.ok(binaryContentList);
+    }
+
+    @GetMapping("/find")
+    public ResponseEntity<BinaryContent> findBinary(@RequestParam UUID binaryContentId) {
+        System.out.println("바이너리 단일(프로필) 파일 조회 API 실행");
+        BinaryContent binaryContent = binaryContentService.find(binaryContentId);
+        System.out.println("binary Content(profile) :" + binaryContent);
+        return ResponseEntity.ok(binaryContent);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
@@ -1,0 +1,62 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.data.ChannelDto;
+import com.sprint.mission.discodeit.dto.request.channel.PrivateChannelCreateRequest;
+import com.sprint.mission.discodeit.dto.request.channel.PublicChannelCreateRequest;
+import com.sprint.mission.discodeit.dto.request.channel.PublicChannelUpdateRequest;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.service.ChannelService;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/channel")
+public class ChannelController {
+    private final ChannelService channelService;
+
+    @PostMapping("/create/public")
+    public ResponseEntity<Channel> createPublic(@RequestBody PublicChannelCreateRequest request) {
+        System.out.println("공개 채널 생성 API가 들어왔습니다.");
+        Channel channel = channelService.create(request);
+        return ResponseEntity.ok(channel);
+    }
+
+    // @Valid 유효성 검사하고, @NotBlack하고 세트임.
+    @PostMapping("/create/private")
+    public ResponseEntity<Channel> createPrivate(@Valid @RequestBody PrivateChannelCreateRequest request) {
+        System.out.println("비공개 채널 생성 API 요청이 들어왔습니다.");
+        Channel channel = channelService.create(request);
+        return ResponseEntity.ok(channel);
+    }
+
+    // 공개 톡방 정보 수정
+    @PutMapping("/{channelId}")
+    public ResponseEntity<Channel> updatePublic(@PathVariable UUID channelId, @RequestBody PublicChannelUpdateRequest request) {
+        System.out.println("공개 톡방 정보 수정 API 요청 들어옴.");
+        Channel channel = channelService.update(channelId, request);
+        return ResponseEntity.ok(channel);
+    }
+
+    //채널 삭제
+    @DeleteMapping("/{channelId}")
+    public ResponseEntity<String> deleteChannel(@PathVariable UUID channelId) {
+        System.out.println("채널 삭제 API 실행");
+        channelService.delete(channelId);
+        return ResponseEntity.ok("delete success");
+    }
+
+    //사용자 채널 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<ChannelDto>> findByUserId(@PathVariable UUID userId) {
+        System.out.println("사용자가 속한 채널 조회 API 실행");
+        List<ChannelDto> channelDtos = channelService.findAllByUserId(userId);
+        return ResponseEntity.ok(channelDtos);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
@@ -1,0 +1,84 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
+import com.sprint.mission.discodeit.dto.request.message.MessageCreateRequest;
+import com.sprint.mission.discodeit.dto.request.message.MessageUpdateRequest;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/message")
+public class MessageController {
+    private final MessageService messageService;
+
+    // formdata 형태로, message, file키로 전달받기
+    // required false, 파일 없어도 메세지 전송 가능
+    @PostMapping("/send")
+    public ResponseEntity<String> sendMessage(
+            @RequestPart("message") MessageCreateRequest request,
+            @RequestPart(value = "file", required = false) List<MultipartFile> files) {
+//        System.out.println("메세지 send 요청 실행");
+//        System.out.println("메세지 작성자 : " + request.authorId());
+//        System.out.println("메세지 채널 : " + request.channelId());
+//        System.out.println("메세지 내용 : " + request.content());
+//
+//        // 파일 정보 확인
+//        if (files != null) {
+//            for (MultipartFile file : files) {
+//                System.out.println("파일명: " + file.getOriginalFilename());
+//                System.out.println("파일타입: " + file.getContentType());
+//                System.out.println("사이즈: " + file.getSize());
+//            }
+//        }
+
+        // MultipartFile → BinaryContentCreateRequest 로 변환, List.of() 불변 (빈)리스트
+        List<BinaryContentCreateRequest> binaryRequests = files == null ? List.of() :
+                files.stream().map(file -> {
+                    try {
+                        return new BinaryContentCreateRequest(
+                                file.getOriginalFilename(),
+                                file.getContentType(),
+                                file.getBytes()
+                        );
+                    } catch (Exception e) {
+                        throw new RuntimeException("파일 변환 실패", e);
+                    }
+                }).toList();
+
+
+        Message message = messageService.create(request, binaryRequests);
+        System.out.println("message + form data :" + message);
+        return ResponseEntity.ok("성공적으로 메세지 전송");
+    }
+
+    @PutMapping("/{messageId}")
+    public ResponseEntity<Message> editMessage(@PathVariable UUID messageId, @RequestBody MessageUpdateRequest request) {
+        System.out.println("메세지 수정 API가 들어왔습니다.");
+        Message message = messageService.update(messageId, request);
+        return ResponseEntity.ok(message);
+    }
+
+    @DeleteMapping("/{messageId}")
+    public ResponseEntity<String> deleteMessage(@PathVariable UUID messageId) {
+        System.out.println("메세지 삭제 API가 들어왔습니다.");
+        messageService.delete(messageId);
+        return ResponseEntity.ok("메세지 삭제 성공");
+    }
+
+    @GetMapping("/{channelId}")
+    public ResponseEntity<List<Message>> findAllByChannelId(@PathVariable UUID channelId) {
+        System.out.println("톡방 메세지 전제 조회 API 실행");
+        List<Message> messageList = messageService.findAllByChannelId(channelId);
+        return ResponseEntity.ok(messageList);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
@@ -1,0 +1,45 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
+import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.service.ReadStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/readstatus")
+public class ReadStatusController {
+    private final ReadStatusService readStatusService;
+
+    @PostMapping("/create")
+    public ResponseEntity<ReadStatus> create(@RequestBody ReadStatusCreateRequest request) {
+        System.out.println("읽음 상태 최초 생성 API 실행");
+        ReadStatus readStatus = readStatusService.create(request);
+        System.out.println("readStatus :" + readStatus);
+        return ResponseEntity.ok(readStatus);
+    }
+
+    @PutMapping("/{readStatusId}")
+    public ResponseEntity<ReadStatus> update(
+            @PathVariable UUID readStatusId,
+            @RequestBody ReadStatusUpdateRequest request) {
+        System.out.println("수신 정보 업데이트 API 실행");
+        ReadStatus readStatus = readStatusService.update(readStatusId, request);
+        return ResponseEntity.ok(readStatus);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<ReadStatus>> findAll(@PathVariable UUID userId) {
+        System.out.println("수신 정보 전체 조회 API 실행");
+        List<ReadStatus> readStatusList = readStatusService.findAllByUserId(userId);
+        System.out.println("참여 톡방 읽음 상태 리스트 : " + readStatusList);
+        return ResponseEntity.ok(readStatusList);
+    }
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
@@ -1,29 +1,75 @@
 package com.sprint.mission.discodeit.controller;
 
+import com.sprint.mission.discodeit.dto.data.UserDto;
 import com.sprint.mission.discodeit.dto.request.user.LoginRequest;
 import com.sprint.mission.discodeit.dto.request.user.UserCreateRequest;
+import com.sprint.mission.discodeit.dto.request.user.UserStatusUpdateRequest;
+import com.sprint.mission.discodeit.dto.request.user.UserUpdateRequest;
+import com.sprint.mission.discodeit.dto.response.user.UserCreateResponse;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.UserStatusService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
 public class UserController {
     private final UserService userService;
+    private final UserStatusService userStatusService;
 
-    public UserController(UserService userService) {
-        this.userService = userService;
-    }
-
+    // 사용자 등록 (회원가입)
     @PostMapping
-    public ResponseEntity<User> createUser(@RequestBody UserCreateRequest request) {
+    public ResponseEntity<UserCreateResponse> createUser(@RequestBody UserCreateRequest request) {
         System.out.println("회원가입 API 요청 들어옴.");
         return ResponseEntity.ok(userService.register(request, Optional.empty()));
+    }
+
+    // 사용자 정보 수정, @PathVariable - URL경로 일부 {}
+    // Post(생성), Get(조회), Put(수정), Delete(삭제)
+    @PutMapping("/{userId}")
+    public ResponseEntity<User> updateUser(@PathVariable UUID userId, @RequestBody UserUpdateRequest request) {
+        System.out.println("사용자 정보 수정 API 요청 들어옴.");
+        User updatedUser = userService.update(userId, request, Optional.empty());
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    // 사용자 삭제
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> deleteUser(@PathVariable UUID userId) {
+        System.out.println("사용자 삭제 API 요청 들어옴.");
+        userService.delete(userId);
+        return ResponseEntity.ok("delete success");
+    }
+
+    // 모든 사용자 조회
+    @GetMapping("/findAll")
+    public ResponseEntity<List<UserDto>> getAllUsers() {
+        System.out.println("모든 사용자 조회 API 요청 들어옴.");
+        List<UserDto> users = userService.findAll();
+        return ResponseEntity.ok(users);
+    }
+
+    // 사용자 온라인 상태 업데이트, Patch로 리소스의 일부분만 업데이트
+    // 프론트가 있어야 UserStatusUpate가 가능하지 않나? API 도구로 현재 시간 전달 불가능/불편
+    @PatchMapping("/{userId}/status")
+    public ResponseEntity<String> updateUserStatus(
+            @PathVariable UUID userId,
+            @RequestBody boolean isOnline
+    ) {
+        System.out.println("사용자 온라인 상태 업데이트 API 요청 들어옴.");
+        Instant newLastActiveAt = isOnline ? Instant.now() : null;
+
+        UserStatusUpdateRequest request = new UserStatusUpdateRequest(newLastActiveAt);
+        userStatusService.updateByUserId(userId, request);
+
+        return ResponseEntity.ok("온라인 상태 업데이트 성공");
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/BinaryContentFindRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/BinaryContentFindRequest.java
@@ -1,0 +1,8 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.util.UUID;
+
+public record BinaryContentFindRequest(
+        UUID binaryContentId
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/channel/PrivateChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/channel/PrivateChannelCreateRequest.java
@@ -1,9 +1,14 @@
 package com.sprint.mission.discodeit.dto.request.channel;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.List;
 import java.util.UUID;
 
 public record PrivateChannelCreateRequest(
+        String name,
+        String description,
+        @NotBlank
         List<UUID> participantIds
 ) {
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/response/user/UserCreateResponse.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/response/user/UserCreateResponse.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.dto.response.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserCreateResponse(
+        String username,
+        String email,
+        UUID profileId,
+        UUID id,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -53,6 +53,7 @@ public class Message implements Serializable {
                 ", content='" + content + '\'' +
                 ", channelId=" + channelId +
                 ", authorId=" + authorId +
+                ", attachmentIds=" + attachmentIds +
                 '}';
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -37,13 +37,8 @@ public class ReadStatus implements Serializable {
      * 사용자가 마지막으로 읽은 메시지 시간 업데이트
      */
     public void update(Instant newLastReadAt) {
-        boolean anyValueUpdated = false;
         if (newLastReadAt != null && !newLastReadAt.equals(this.lastReadAt)) {
             this.lastReadAt = newLastReadAt;
-            anyValueUpdated = true;
-        }
-
-        if (anyValueUpdated) {
             this.updatedAt = Instant.now();
         }
     }

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -3,6 +3,7 @@ package com.sprint.mission.discodeit.entity;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -12,7 +13,9 @@ import java.util.UUID;
  */
 
 @Getter
-public class ReadStatus {
+public class ReadStatus implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final UUID id;
     private final Instant createdAt;
     private Instant updatedAt;

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileBinaryContentRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileBinaryContentRepository.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 @Repository
 public class FileBinaryContentRepository implements BinaryContentRepository {
     private final Path DIRECTORY;
-    private final String EXTENSION = ".ser";
+    private static final String EXTENSION = ".ser";
 
     public FileBinaryContentRepository(
 //            @Value("${discodeit.repository.file-directory:data}") String fileDirectory

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Repository
 public class FileChannelRepository implements ChannelRepository {
     private final Path DIRECTORY;
-    private final String EXTENSION = ".ser";
+    private static final String EXTENSION = ".ser";
 
     public FileChannelRepository() {
 //        @Value("${discodeit.repository.file-directory:data}") String fileDirectory

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 @Repository
 public class FileMessageRepository implements MessageRepository {
     private final Path DIRECTORY;
-    private final String EXTENSION = ".ser";
+    private static final String EXTENSION = ".ser";
 
     public FileMessageRepository(
 //            @Value("${discodeit.repository.file-directory:data}") String fileDirectory

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 @Repository
 public class FileReadStatusRepository implements ReadStatusRepository {
     private final Path DIRECTORY;
-    private final String EXTENSION = ".ser";
+    private static final String EXTENSION = ".ser";
 
     public FileReadStatusRepository(
 //            @Value("${discodeit.repository.file-directory:data}") String fileDirectory

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 @Repository
 public class FileUserRepository implements UserRepository {
     private final Path DIRECTORY;
-    private final String EXTENSION = ".ser";
+    private static final String EXTENSION = ".ser";
 
     public FileUserRepository() {
         this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "repositoryToFile", User.class.getSimpleName());

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserStatusRepository.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 @Repository
 public class FileUserStatusRepository implements UserStatusRepository {
     private final Path DIRECTORY;
-    private final String EXTENSION = ".ser";
+    private static final String EXTENSION = ".ser";
 
     public FileUserStatusRepository(
 //            @Value("${discodeit.repository.file-directory:data}") String fileDirectory

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -4,6 +4,7 @@ import com.sprint.mission.discodeit.dto.data.UserDto;
 import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto.request.user.UserCreateRequest;
 import com.sprint.mission.discodeit.dto.request.user.UserUpdateRequest;
+import com.sprint.mission.discodeit.dto.response.user.UserCreateResponse;
 import com.sprint.mission.discodeit.entity.User;
 
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserService {
-    User register(UserCreateRequest userCreateRequest, Optional<BinaryContentCreateRequest> profileCreateRequest);
+    UserCreateResponse register(UserCreateRequest userCreateRequest, Optional<BinaryContentCreateRequest> profileCreateRequest);
     UserDto find(UUID userId);
     List<UserDto> findAll();
     User update(UUID userId, UserUpdateRequest userUpdateRequest, Optional<BinaryContentCreateRequest> profileCreateRequest);

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthServiceImp.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthServiceImp.java
@@ -2,17 +2,21 @@ package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.request.user.LoginRequest;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
 @Service
 public class BasicAuthServiceImp implements AuthService {
     private final UserRepository userRepository;
+    private final UserStatusRepository userStatusRepository;
 
     @Override
     public User login(LoginRequest loginRequest) {
@@ -25,6 +29,19 @@ public class BasicAuthServiceImp implements AuthService {
         if (!user.getPassword().equals(password)) {
             throw new IllegalArgumentException("Wrong password");
         }
+
+        userStatusRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                        status -> {
+                            status.update(Instant.now());  // ✅ 마지막 활동 시간만 업데이트
+                            userStatusRepository.save(status);
+                        },
+                        () -> {
+                            UserStatus newStatus = new UserStatus(user.getId(), Instant.now());
+                            userStatusRepository.save(newStatus);
+                        }
+                );
+
 
         return user;
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentServiceImp.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentServiceImp.java
@@ -38,6 +38,7 @@ public class BasicBinaryContentServiceImp implements BinaryContentService {
 
     @Override
     public List<BinaryContent> findAllByIdIn(List<UUID> binaryContentIds) {
+        // 특정 메세지에 포함된 파일 모두 조회 -> 다운로드
         return binaryContentRepository.findAllByIdIn(binaryContentIds).stream()
                 .toList();
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageServiceImp.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageServiceImp.java
@@ -38,6 +38,8 @@ public class BasicMessageServiceImp implements MessageService {
             throw new NoSuchElementException("Author with id " + authorId + " does not exist");
         }
 
+        System.out.println("[MessageService] List attachmentIds :" + binaryContentCreateRequests );
+
         List<UUID> attachmentIds = binaryContentCreateRequests.stream()
                 .map(attachmentRequest -> {
                     String fileName = attachmentRequest.fileName();

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusServiceImp.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusServiceImp.java
@@ -22,6 +22,7 @@ public class BasicReadStatusServiceImp implements ReadStatusService {
     private final UserRepository userRepository;
     private final ChannelRepository channelRepository;
 
+    // 수신 정보 등록, 새로운 메세지 읽음 여부
     @Override
     public ReadStatus create(ReadStatusCreateRequest request) {
         UUID userId = request.userId();
@@ -33,6 +34,7 @@ public class BasicReadStatusServiceImp implements ReadStatusService {
         if (!channelRepository.existsById(channelId)) {
             throw new NoSuchElementException("Channel with id " + channelId + " does not exist");
         }
+        // 유저가 이미 읽은 상태 (톡방을 실시간으로 보고 있는 경우, 최신 메세지를 본 경우)에 대한 중복 읽음 상태 등록 방지
         if (readStatusRepository.findAllByUserId(userId).stream()
                 .anyMatch(readStatus -> readStatus.getChannelId().equals(channelId))) {
             throw new IllegalArgumentException("ReadStatus with userId " + userId + " and channelId " + channelId + " already exists");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,9 @@ discodeit:
   repository:
     type: file   # jcf | file
     file-directory: .discodeit
+
+servlet:
+  multipart:
+    enabled: true                # 멀티파트 요청 허용 (기본값 true지만 명시해도 OK)
+    max-file-size: 10MB         # 개별 파일 최대 크기
+    max-request-size: 20MB      # 전체 요청 최대 크기 (파일 여러 개 합산)


### PR DESCRIPTION
## 요구사항

### 기본
컨트롤러 레이어 구현
[x]  DiscodeitApplication의 테스트 로직은 삭제하세요.

[x]  지금까지 구현한 서비스 로직을 활용해 웹 API를 구현하세요.  
이때 @RequestMapping만 사용해 구현해보세요.

##웹 API 요구사항
###사용자 관리
[x] 사용자를 등록할 수 있다.
[x] 사용자 정보를 수정할 수 있다.
[x] 사용자를 삭제할 수 있다.
[x] 모든 사용자를 조회할 수 있다.
[x] 사용자의 온라인 상태를 업데이트할 수 있다.

###권한 관리
[x] 사용자는 로그인할 수 있다.

###채널 관리
[x] 공개 채널을 생성할 수 있다.
[x] 비공개 채널을 생성할 수 있다.
[x] 공개 채널의 정보를 수정할 수 있다.
[x] 채널을 삭제할 수 있다.
[x] 특정 사용자가 볼 수 있는 모든 채널 목록을 조회할 수 있다.

###메시지 관리
[x] 메시지를 보낼 수 있다.
[x] 메시지를 수정할 수 있다.
[x] 메시지를 삭제할 수 있다.
[x] 특정 채널의 메시지 목록을 조회할 수 있다.

###메시지 수신 정보 관리
[x] 특정 채널의 메시지 수신 정보를 생성할 수 있다.
[x] 특정 채널의 메시지 수신 정보를 수정할 수 있다.
[x] 특정 사용자의 메시지 수신 정보를 조회할 수 있다.

###바이너리 파일 다운로드
[x] 바이너리 파일을 1개 또는 여러 개 조회할 수 있다.

[ ]  웹 API의 예외를 전역으로 처리하세요.

###API 테스트
[x] Postman을 활용해 컨트롤러를 테스트 하세요.
Postman API 테스트 결과를 다음과 같이 export하여 PR에 첨부해주세요.

## 심화
###정적 리소스 서빙
[x]  사용자 목록 조회, BinaryContent 파일 조회 API를 다음의 조건을 만족하도록 수정하세요.
[x]  사용자 목록 조회
url: /api/user/findAll
요청: 파라미터, 바디 없음
응답: ResponseEntity<List<UserDto>>

[x]  BinaryContent 파일 조회

url: /api/binaryContent/find
요청
파라미터: binaryContentId
바디 없음
응답: ResponseEntity<BinaryContent>
[x]  다음의 파일을 활용하여 사용자 목록을 보여주는 화면을 서빙해보세요.

## 주요 변경사항
- 미션 3 코드는 코드잇에서 제공하는 베이스 코드 반영했습니다. 추가로 일부 피드백 주신 부분 반영했습니다.
- 컨트롤러 구현, API 테스트

## 스크린샷
<img width="1210" alt="Image" src="https://github.com/user-attachments/assets/845651a2-7f2f-4415-b4ae-d4c3eec27d4a" />

## 멘토에게
- 실무 피드백 많이 부탁드립니다!
