### PR TITLE
[박상혁] sprint4

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -15,9 +15,6 @@ import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.MessageService;
 import com.sprint.mission.discodeit.service.UserService;
-import com.sprint.mission.discodeit.service.basic.BasicChannelService;
-import com.sprint.mission.discodeit.service.basic.BasicMessageService;
-import com.sprint.mission.discodeit.service.basic.BasicUserService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -209,7 +206,7 @@ public class DiscodeitApplication {
         // 존재하지 않는 유저로 생성
         try {
             Message message = messageService.create(
-                    new MessageCreateDto(UUID.randomUUID(), privateChannel.getId(), "안녕하세요.", null));
+                    new MessageCreateDto(UUID.randomUUID(), privateChannel.getId(), "안녕하세요.", List.of()));
             System.out.println("메시지 생성: " + message.getId());
         } catch (RuntimeException e) {
             System.out.println("메시지 생성 실패: " + e.getMessage());
@@ -218,7 +215,7 @@ public class DiscodeitApplication {
         // 존재하지 않는 채널로 생성
         try {
             Message message = messageService.create(
-                    new MessageCreateDto(user.getId(), UUID.randomUUID(), "안녕하세요.", null));
+                    new MessageCreateDto(user.getId(), UUID.randomUUID(), "안녕하세요.", List.of()));
             System.out.println("메시지 생성: " + message.getId());
         } catch (RuntimeException e) {
             System.out.println("메시지 생성 실패: " + e.getMessage());
@@ -236,7 +233,7 @@ public class DiscodeitApplication {
 
         try {
             Message message = messageService.create(
-                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 조회 테스트", null));
+                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 조회 테스트", List.of()));
             Message foundMessage = messageService.findById(message.getId());
             System.out.println("메시지 조회(단건): " + foundMessage.getId());
         } catch (RuntimeException e) {
@@ -254,7 +251,7 @@ public class DiscodeitApplication {
         // 수정
         try {
             Message message = messageService.create(
-                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 수정 테스트", null));
+                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 수정 테스트", List.of()));
             Message updatedMessage = messageService.update(new MessageUpdateDto(message.getId(), "메시지 수정 성공 테스트입니다."));
             System.out.println("메시지 수정: " + updatedMessage.getContent());
         } catch (RuntimeException e) {
@@ -272,7 +269,7 @@ public class DiscodeitApplication {
 
         // 삭제
         Message deletedMessage = messageService.create(
-                new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 삭제 테스트", null));
+                new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 삭제 테스트", List.of()));
         List<Message> foundMessagesBeforeDelete = messageService.findAllByChannelId(privateChannel.getId());
         System.out.println("메시지 삭제 전: " + foundMessagesBeforeDelete.size());
         messageService.delete(deletedMessage.getId());
@@ -283,15 +280,15 @@ public class DiscodeitApplication {
     public static void main(String[] args) {
         ConfigurableApplicationContext context = SpringApplication.run(DiscodeitApplication.class, args);
 
-        // 서비스 초기화
-        UserService userService = context.getBean(BasicUserService.class);
-        ChannelService channelService = context.getBean(BasicChannelService.class);
-        MessageService messageService = context.getBean(BasicMessageService.class);
-
-        // 테스트
-        userCRUDTest(userService);
-        channelCRUDTest(channelService, userService);
-        messageCRUDTest(messageService, userService, channelService);
+//        // 서비스 초기화
+//        UserService userService = context.getBean(BasicUserService.class);
+//        ChannelService channelService = context.getBean(BasicChannelService.class);
+//        MessageService messageService = context.getBean(BasicMessageService.class);
+//
+//        // 테스트
+//        userCRUDTest(userService);
+//        channelCRUDTest(channelService, userService);
+//        messageCRUDTest(messageService, userService, channelService);
     }
 
 }

--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -2,12 +2,12 @@ package com.sprint.mission.discodeit;
 
 import com.sprint.mission.discodeit.dto.channel.ChannelCreatePrivateDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelCreatePublicDto;
-import com.sprint.mission.discodeit.dto.channel.ChannelResponseDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelUpdateDto;
 import com.sprint.mission.discodeit.dto.message.MessageCreateDto;
 import com.sprint.mission.discodeit.dto.message.MessageUpdateDto;
 import com.sprint.mission.discodeit.dto.user.UserCreateDto;
-import com.sprint.mission.discodeit.dto.user.UserResponseDto;
+import com.sprint.mission.discodeit.dto.user.UserDto;
 import com.sprint.mission.discodeit.dto.user.UserUpdateDto;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.Message;
@@ -47,13 +47,13 @@ public class DiscodeitApplication {
         }
 
         // 조회
-        List<UserResponseDto> foundUsers = userService.findAll();
+        List<UserDto> foundUsers = userService.findAll();
         System.out.println("유저 조회(다건): " + foundUsers.size());
 
         try {
             UserCreateDto userCreateDto = new UserCreateDto("findTest", "findTest@codeit.com", "test1234", null);
             User user = userService.create(userCreateDto);
-            UserResponseDto foundUser = userService.findById(user.getId());
+            UserDto foundUser = userService.findById(user.getId());
             System.out.println("유저 조회(단건): " + foundUser.id());
         } catch (RuntimeException e) {
             System.out.println("유저 조회(단건) 실패: " + e.getMessage());
@@ -61,7 +61,7 @@ public class DiscodeitApplication {
 
         // 존재하지 않는 ID 조회
         try {
-            UserResponseDto foundUser = userService.findById(UUID.randomUUID());
+            UserDto foundUser = userService.findById(UUID.randomUUID());
             System.out.println("유저 조회(단건): " + foundUser.id());
         } catch (RuntimeException e) {
             System.out.println("유저 조회(단건) 실패: " + e.getMessage());
@@ -96,10 +96,10 @@ public class DiscodeitApplication {
         UserCreateDto userCreateDto = new UserCreateDto("deletedTest", "deletedTest@codeit.com", "deletedTest1234",
                 null);
         User deletedUser = userService.create(userCreateDto);
-        List<UserResponseDto> foundUsersBeforeDelete = userService.findAll();
+        List<UserDto> foundUsersBeforeDelete = userService.findAll();
         System.out.println("유저 삭제 전: " + foundUsersBeforeDelete.size());
         userService.delete(deletedUser.getId());
-        List<UserResponseDto> foundUsersAfterDelete = userService.findAll();
+        List<UserDto> foundUsersAfterDelete = userService.findAll();
         System.out.println("유저 삭제 후: " + foundUsersAfterDelete.size());
     }
 
@@ -143,11 +143,11 @@ public class DiscodeitApplication {
         ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("testPublic", "testPublic");
         Channel publicChannel = channelService.createPublic(channelCreatePublicDto);
 
-        List<ChannelResponseDto> foundChannels = channelService.findAllByUserId(user.getId());
+        List<ChannelDto> foundChannels = channelService.findAllByUserId(user.getId());
         System.out.println("채널 조회(다건): " + foundChannels.size());
 
         try {
-            ChannelResponseDto foundChannel = channelService.findById(privateChannel.getId());
+            ChannelDto foundChannel = channelService.findById(privateChannel.getId());
             System.out.println("채널 조회(단건): " + foundChannel.id());
         } catch (RuntimeException e) {
             System.out.println("채널 조회(단건) 실패: " + e.getMessage());
@@ -155,7 +155,7 @@ public class DiscodeitApplication {
 
         // 존재하지 않는 ID 조회
         try {
-            ChannelResponseDto foundChannel = channelService.findById(UUID.randomUUID());
+            ChannelDto foundChannel = channelService.findById(UUID.randomUUID());
             System.out.println("채널 조회(단건): " + foundChannel.id());
         } catch (RuntimeException e) {
             System.out.println("채널 조회(단건) 실패: " + e.getMessage());
@@ -181,10 +181,10 @@ public class DiscodeitApplication {
         }
 
         // 삭제
-        List<ChannelResponseDto> foundChannelsBeforeDelete = channelService.findAllByUserId(user.getId());
+        List<ChannelDto> foundChannelsBeforeDelete = channelService.findAllByUserId(user.getId());
         System.out.println("채널 삭제 전: " + foundChannelsBeforeDelete.size());
         channelService.delete(publicChannel.getId());
-        List<ChannelResponseDto> foundChannelsAfterDelete = channelService.findAllByUserId(user.getId());
+        List<ChannelDto> foundChannelsAfterDelete = channelService.findAllByUserId(user.getId());
         System.out.println("채널 삭제: " + foundChannelsAfterDelete.size());
     }
 

--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,282 +1,264 @@
 package com.sprint.mission.discodeit;
 
-import com.sprint.mission.discodeit.dto.channel.ChannelCreatePrivateDto;
-import com.sprint.mission.discodeit.dto.channel.ChannelCreatePublicDto;
-import com.sprint.mission.discodeit.dto.channel.ChannelDto;
-import com.sprint.mission.discodeit.dto.channel.ChannelUpdateDto;
-import com.sprint.mission.discodeit.dto.message.MessageCreateDto;
-import com.sprint.mission.discodeit.dto.message.MessageUpdateDto;
-import com.sprint.mission.discodeit.dto.user.UserCreateDto;
-import com.sprint.mission.discodeit.dto.user.UserDto;
-import com.sprint.mission.discodeit.dto.user.UserUpdateDto;
-import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.entity.Message;
-import com.sprint.mission.discodeit.entity.User;
-import com.sprint.mission.discodeit.service.ChannelService;
-import com.sprint.mission.discodeit.service.MessageService;
-import com.sprint.mission.discodeit.service.UserService;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
 @SpringBootApplication
 public class DiscodeitApplication {
-    static void userCRUDTest(UserService userService) {
-        // 생성
-        try {
-            UserCreateDto userCreateDto = new UserCreateDto("sang", "sang@codeit.com", "sang1234", null);
-            User user = userService.create(userCreateDto);
-            System.out.println("유저 생성: " + user.getId());
-        } catch (RuntimeException e) {
-            System.out.println("유저 생성 실패: " + e.getMessage());
-        }
-
-        // 동일한 유저 email로 생성
-        try {
-            UserCreateDto userCreateDto = new UserCreateDto("park", "sang@codeit.com", "park1234", null);
-            User user = userService.create(userCreateDto);
-            System.out.println("유저 생성: " + user.getId());
-        } catch (RuntimeException e) {
-            System.out.println("유저 생성 실패: " + e.getMessage());
-        }
-
-        // 조회
-        List<UserDto> foundUsers = userService.findAll();
-        System.out.println("유저 조회(다건): " + foundUsers.size());
-
-        try {
-            UserCreateDto userCreateDto = new UserCreateDto("findTest", "findTest@codeit.com", "test1234", null);
-            User user = userService.create(userCreateDto);
-            UserDto foundUser = userService.findById(user.getId());
-            System.out.println("유저 조회(단건): " + foundUser.id());
-        } catch (RuntimeException e) {
-            System.out.println("유저 조회(단건) 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 ID 조회
-        try {
-            UserDto foundUser = userService.findById(UUID.randomUUID());
-            System.out.println("유저 조회(단건): " + foundUser.id());
-        } catch (RuntimeException e) {
-            System.out.println("유저 조회(단건) 실패: " + e.getMessage());
-        }
-
-        // 수정
-        try {
-            UserCreateDto userCreateDto = new UserCreateDto("updateTest", "updateTest@codeit.com", "updateTest1234",
-                    null);
-            User user = userService.create(userCreateDto);
-            UserUpdateDto userUpdateDto = new UserUpdateDto(user.getId(), null, null, "woody5678", null);
-            User updatedUser = userService.update(userUpdateDto);
-            System.out.println("유저 수정: " + String.join("/", updatedUser.getUsername(), updatedUser.getEmail(),
-                    updatedUser.getPassword(),
-                    updatedUser.getProfileId() == null ? "null" : updatedUser.getProfileId().toString()));
-        } catch (RuntimeException e) {
-            System.out.println("유저 수정 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 ID로 수정
-        try {
-            UserUpdateDto userUpdateDto = new UserUpdateDto(UUID.randomUUID(), null, null, "woody5678", null);
-            User updatedUser = userService.update(userUpdateDto);
-            System.out.println("유저 수정: " + String.join("/", updatedUser.getUsername(), updatedUser.getEmail(),
-                    updatedUser.getPassword(),
-                    updatedUser.getProfileId() == null ? "null" : updatedUser.getProfileId().toString()));
-        } catch (RuntimeException e) {
-            System.out.println("유저 수정 실패: " + e.getMessage());
-        }
-
-        // 삭제
-        UserCreateDto userCreateDto = new UserCreateDto("deletedTest", "deletedTest@codeit.com", "deletedTest1234",
-                null);
-        User deletedUser = userService.create(userCreateDto);
-        List<UserDto> foundUsersBeforeDelete = userService.findAll();
-        System.out.println("유저 삭제 전: " + foundUsersBeforeDelete.size());
-        userService.delete(deletedUser.getId());
-        List<UserDto> foundUsersAfterDelete = userService.findAll();
-        System.out.println("유저 삭제 후: " + foundUsersAfterDelete.size());
-    }
-
-    static void channelCRUDTest(ChannelService channelService, UserService userService) {
-        // 생성
-
-        // public 채널 생성
-        try {
-            ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("Public 채널", "Public 채널입니다.");
-            Channel channel = channelService.createPublic(channelCreatePublicDto);
-            System.out.println("채널 생성: " + channel.getId());
-        } catch (RuntimeException e) {
-            System.out.println("채널 생성 실패: " + e.getMessage());
-        }
-
-        // private 채널 생성
-        try {
-            ChannelCreatePrivateDto channelCreatePrivateDto = new ChannelCreatePrivateDto(new ArrayList<>());
-            Channel channel = channelService.createPrivate(channelCreatePrivateDto);
-            System.out.println("채널 생성: " + channel.getId());
-        } catch (RuntimeException e) {
-            System.out.println("채널 생성 실패: " + e.getMessage());
-        }
-
-        // 동일한 채널 이름으로 생성
-        try {
-            ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("Public 채널",
-                    "Public 채널 또 만듭니다.");
-            Channel channel = channelService.createPublic(channelCreatePublicDto);
-            System.out.println("채널 생성: " + channel.getId());
-        } catch (RuntimeException e) {
-            System.out.println("채널 생성 실패: " + e.getMessage());
-        }
-
-        // 조회
-        UserCreateDto userCreateDto = new UserCreateDto("test", "test@codeit.com", "test", null);
-        User user = userService.create(userCreateDto);
-
-        ChannelCreatePrivateDto channelCreatePrivateDto = new ChannelCreatePrivateDto(List.of(user));
-        Channel privateChannel = channelService.createPrivate(channelCreatePrivateDto);
-        ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("testPublic", "testPublic");
-        Channel publicChannel = channelService.createPublic(channelCreatePublicDto);
-
-        List<ChannelDto> foundChannels = channelService.findAllByUserId(user.getId());
-        System.out.println("채널 조회(다건): " + foundChannels.size());
-
-        try {
-            ChannelDto foundChannel = channelService.findById(privateChannel.getId());
-            System.out.println("채널 조회(단건): " + foundChannel.id());
-        } catch (RuntimeException e) {
-            System.out.println("채널 조회(단건) 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 ID 조회
-        try {
-            ChannelDto foundChannel = channelService.findById(UUID.randomUUID());
-            System.out.println("채널 조회(단건): " + foundChannel.id());
-        } catch (RuntimeException e) {
-            System.out.println("채널 조회(단건) 실패: " + e.getMessage());
-        }
-
-        // 수정
-        try {
-            ChannelUpdateDto channelUpdateDto = new ChannelUpdateDto(publicChannel.getId(), "수정 성공 테스트",
-                    "수정 성공 테스트 채널입니다.");
-            Channel updatedChannel = channelService.update(channelUpdateDto);
-            System.out.println("채널 수정: " + String.join("/", updatedChannel.getName(), updatedChannel.getDescription()));
-        } catch (RuntimeException e) {
-            System.out.println("채널 수정 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 ID로 수정
-        try {
-            Channel updatedChannel = channelService.update(
-                    new ChannelUpdateDto(UUID.randomUUID(), "수정 실패 테스트", "수정 실패 테스트 채널입니다."));
-            System.out.println("채널 수정: " + String.join("/", updatedChannel.getName(), updatedChannel.getDescription()));
-        } catch (RuntimeException e) {
-            System.out.println("채널 수정 실패: " + e.getMessage());
-        }
-
-        // 삭제
-        List<ChannelDto> foundChannelsBeforeDelete = channelService.findAllByUserId(user.getId());
-        System.out.println("채널 삭제 전: " + foundChannelsBeforeDelete.size());
-        channelService.delete(publicChannel.getId());
-        List<ChannelDto> foundChannelsAfterDelete = channelService.findAllByUserId(user.getId());
-        System.out.println("채널 삭제: " + foundChannelsAfterDelete.size());
-    }
-
-    static void messageCRUDTest(MessageService messageService, UserService userService, ChannelService channelService) {
-        UserCreateDto userCreateDto = new UserCreateDto("MessageTester", "test@codeit.com", "MessageTester", null);
-        User user = userService.create(userCreateDto);
-
-        ChannelCreatePrivateDto channelCreatePrivateDto = new ChannelCreatePrivateDto(List.of(user));
-        Channel privateChannel = channelService.createPrivate(channelCreatePrivateDto);
+//    static void userCRUDTest(UserService userService) {
+//        // 생성
+//        try {
+//            UserCreateDto userCreateDto = new UserCreateDto("sang", "sang@codeit.com", "sang1234", null);
+//            User user = userService.create(userCreateDto);
+//            System.out.println("유저 생성: " + user.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("유저 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 동일한 유저 email로 생성
+//        try {
+//            UserCreateDto userCreateDto = new UserCreateDto("park", "sang@codeit.com", "park1234", null);
+//            User user = userService.create(userCreateDto);
+//            System.out.println("유저 생성: " + user.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("유저 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 조회
+//        List<UserDto> foundUsers = userService.findAll();
+//        System.out.println("유저 조회(다건): " + foundUsers.size());
+//
+//        try {
+//            UserCreateDto userCreateDto = new UserCreateDto("findTest", "findTest@codeit.com", "test1234", null);
+//            User user = userService.create(userCreateDto);
+//            UserDto foundUser = userService.findById(user.getId());
+//            System.out.println("유저 조회(단건): " + foundUser.id());
+//        } catch (RuntimeException e) {
+//            System.out.println("유저 조회(단건) 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 ID 조회
+//        try {
+//            UserDto foundUser = userService.findById(UUID.randomUUID());
+//            System.out.println("유저 조회(단건): " + foundUser.id());
+//        } catch (RuntimeException e) {
+//            System.out.println("유저 조회(단건) 실패: " + e.getMessage());
+//        }
+//
+//        // 수정
+//        try {
+//            UserCreateDto userCreateDto = new UserCreateDto("updateTest", "updateTest@codeit.com", "updateTest1234",
+//                    null);
+//            User user = userService.create(userCreateDto);
+//            UserUpdateDto userUpdateDto = new UserUpdateDto(user.getId(), null, null, "woody5678", null);
+//            User updatedUser = userService.update(userUpdateDto);
+//            System.out.println("유저 수정: " + String.join("/", updatedUser.getUsername(), updatedUser.getEmail(),
+//                    updatedUser.getPassword(),
+//                    updatedUser.getProfileId() == null ? "null" : updatedUser.getProfileId().toString()));
+//        } catch (RuntimeException e) {
+//            System.out.println("유저 수정 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 ID로 수정
+//        try {
+//            UserUpdateDto userUpdateDto = new UserUpdateDto(UUID.randomUUID(), null, null, "woody5678", null);
+//            User updatedUser = userService.update(userUpdateDto);
+//            System.out.println("유저 수정: " + String.join("/", updatedUser.getUsername(), updatedUser.getEmail(),
+//                    updatedUser.getPassword(),
+//                    updatedUser.getProfileId() == null ? "null" : updatedUser.getProfileId().toString()));
+//        } catch (RuntimeException e) {
+//            System.out.println("유저 수정 실패: " + e.getMessage());
+//        }
+//
+//        // 삭제
+//        UserCreateDto userCreateDto = new UserCreateDto("deletedTest", "deletedTest@codeit.com", "deletedTest1234",
+//                null);
+//        User deletedUser = userService.create(userCreateDto);
+//        List<UserDto> foundUsersBeforeDelete = userService.findAll();
+//        System.out.println("유저 삭제 전: " + foundUsersBeforeDelete.size());
+//        userService.delete(deletedUser.getId());
+//        List<UserDto> foundUsersAfterDelete = userService.findAll();
+//        System.out.println("유저 삭제 후: " + foundUsersAfterDelete.size());
+//    }
+//
+//    static void channelCRUDTest(ChannelService channelService, UserService userService) {
+//        // 생성
+//
+//        // public 채널 생성
+//        try {
+//            ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("Public 채널", "Public 채널입니다.");
+//            Channel channel = channelService.createPublic(channelCreatePublicDto);
+//            System.out.println("채널 생성: " + channel.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 생성 실패: " + e.getMessage());
+//        }
+//
+//        // private 채널 생성
+//        try {
+//            ChannelCreatePrivateDto channelCreatePrivateDto = new ChannelCreatePrivateDto(new ArrayList<>());
+//            Channel channel = channelService.createPrivate(channelCreatePrivateDto);
+//            System.out.println("채널 생성: " + channel.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 동일한 채널 이름으로 생성
+//        try {
+//            ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("Public 채널",
+//                    "Public 채널 또 만듭니다.");
+//            Channel channel = channelService.createPublic(channelCreatePublicDto);
+//            System.out.println("채널 생성: " + channel.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 조회
+//        UserCreateDto userCreateDto = new UserCreateDto("test", "test@codeit.com", "test", null);
+//        User user = userService.create(userCreateDto);
+//
+//        ChannelCreatePrivateDto channelCreatePrivateDto = new ChannelCreatePrivateDto(List.of(user));
+//        Channel privateChannel = channelService.createPrivate(channelCreatePrivateDto);
 //        ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("testPublic", "testPublic");
 //        Channel publicChannel = channelService.createPublic(channelCreatePublicDto);
-        // 생성
-        try {
-            MessageCreateDto messageCreateDto = new MessageCreateDto(user.getId(), privateChannel.getId(), "안녕하세요.",
-                    null);
-            Message message = messageService.create(messageCreateDto);
-            System.out.println("메시지 생성: " + message.getId());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 생성 실패: " + e.getMessage());
-        }
+//
+//        List<ChannelDto> foundChannels = channelService.findAllByUserId(user.getId());
+//        System.out.println("채널 조회(다건): " + foundChannels.size());
+//
+//        try {
+//            ChannelDto foundChannel = channelService.findById(privateChannel.getId());
+//            System.out.println("채널 조회(단건): " + foundChannel.id());
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 조회(단건) 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 ID 조회
+//        try {
+//            ChannelDto foundChannel = channelService.findById(UUID.randomUUID());
+//            System.out.println("채널 조회(단건): " + foundChannel.id());
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 조회(단건) 실패: " + e.getMessage());
+//        }
+//
+//        // 수정
+//        try {
+//            ChannelUpdateDto channelUpdateDto = new ChannelUpdateDto(publicChannel.getId(), "수정 성공 테스트",
+//                    "수정 성공 테스트 채널입니다.");
+//            Channel updatedChannel = channelService.update(channelUpdateDto);
+//            System.out.println("채널 수정: " + String.join("/", updatedChannel.getName(), updatedChannel.getDescription()));
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 수정 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 ID로 수정
+//        try {
+//            Channel updatedChannel = channelService.update(
+//                    new ChannelUpdateDto(UUID.randomUUID(), "수정 실패 테스트", "수정 실패 테스트 채널입니다."));
+//            System.out.println("채널 수정: " + String.join("/", updatedChannel.getName(), updatedChannel.getDescription()));
+//        } catch (RuntimeException e) {
+//            System.out.println("채널 수정 실패: " + e.getMessage());
+//        }
+//
+//        // 삭제
+//        List<ChannelDto> foundChannelsBeforeDelete = channelService.findAllByUserId(user.getId());
+//        System.out.println("채널 삭제 전: " + foundChannelsBeforeDelete.size());
+//        channelService.delete(publicChannel.getId());
+//        List<ChannelDto> foundChannelsAfterDelete = channelService.findAllByUserId(user.getId());
+//        System.out.println("채널 삭제: " + foundChannelsAfterDelete.size());
+//    }
+//
+//    static void messageCRUDTest(MessageService messageService, UserService userService, ChannelService channelService) {
+//        UserCreateDto userCreateDto = new UserCreateDto("MessageTester", "test@codeit.com", "MessageTester", null);
+//        User user = userService.create(userCreateDto);
+//
+//        ChannelCreatePrivateDto channelCreatePrivateDto = new ChannelCreatePrivateDto(List.of(user));
+//        Channel privateChannel = channelService.createPrivate(channelCreatePrivateDto);
 
-        // 존재하지 않는 유저로 생성
-        try {
-            Message message = messageService.create(
-                    new MessageCreateDto(UUID.randomUUID(), privateChannel.getId(), "안녕하세요.", List.of()));
-            System.out.println("메시지 생성: " + message.getId());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 생성 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 채널로 생성
-        try {
-            Message message = messageService.create(
-                    new MessageCreateDto(user.getId(), UUID.randomUUID(), "안녕하세요.", List.of()));
-            System.out.println("메시지 생성: " + message.getId());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 생성 실패: " + e.getMessage());
-        }
-
-        // 조회
-
-        // 채널 ID로 조회
-        List<Message> foundMessagesByChannelId = messageService.findAllByChannelId(privateChannel.getId());
-        System.out.println("채널 내 메시지 조회(다건): " + foundMessagesByChannelId.size());
-
-        // 유저 ID로 조회
-        List<Message> foundMessagesByAuthorId = messageService.findAllByAuthorId(user.getId());
-        System.out.println("유저가 쓴 메시지 조회(다건): " + foundMessagesByAuthorId.size());
-
-        try {
-            Message message = messageService.create(
-                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 조회 테스트", List.of()));
-            Message foundMessage = messageService.findById(message.getId());
-            System.out.println("메시지 조회(단건): " + foundMessage.getId());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 조회(단건) 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 ID 조회
-        try {
-            Message foundMessage = messageService.findById(UUID.randomUUID());
-            System.out.println("메시지 조회(단건): " + foundMessage.getId());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 조회(단건) 실패: " + e.getMessage());
-        }
-
-        // 수정
-        try {
-            Message message = messageService.create(
-                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 수정 테스트", List.of()));
-            Message updatedMessage = messageService.update(new MessageUpdateDto(message.getId(), "메시지 수정 성공 테스트입니다."));
-            System.out.println("메시지 수정: " + updatedMessage.getContent());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 수정 실패: " + e.getMessage());
-        }
-
-        // 존재하지 않는 ID로 수정
-        try {
-            Message updatedMessage = messageService.update(
-                    new MessageUpdateDto(UUID.randomUUID(), "메시지 수정 실패 테스트입니다."));
-            System.out.println("메시지 수정: " + updatedMessage.getContent());
-        } catch (RuntimeException e) {
-            System.out.println("메시지 수정 실패: " + e.getMessage());
-        }
-
-        // 삭제
-        Message deletedMessage = messageService.create(
-                new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 삭제 테스트", List.of()));
-        List<Message> foundMessagesBeforeDelete = messageService.findAllByChannelId(privateChannel.getId());
-        System.out.println("메시지 삭제 전: " + foundMessagesBeforeDelete.size());
-        messageService.delete(deletedMessage.getId());
-        List<Message> foundMessagesAfterDelete = messageService.findAllByChannelId(privateChannel.getId());
-        System.out.println("메시지 삭제: " + foundMessagesAfterDelete.size());
-    }
-
+    /// /        ChannelCreatePublicDto channelCreatePublicDto = new ChannelCreatePublicDto("testPublic", "testPublic");
+    /// /        Channel publicChannel = channelService.createPublic(channelCreatePublicDto);
+//        // 생성
+//        try {
+//            MessageCreateDto messageCreateDto = new MessageCreateDto(user.getId(), privateChannel.getId(), "안녕하세요.",
+//                    null);
+//            Message message = messageService.create(messageCreateDto);
+//            System.out.println("메시지 생성: " + message.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 유저로 생성
+//        try {
+//            Message message = messageService.create(
+//                    new MessageCreateDto(UUID.randomUUID(), privateChannel.getId(), "안녕하세요.", List.of()));
+//            System.out.println("메시지 생성: " + message.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 채널로 생성
+//        try {
+//            Message message = messageService.create(
+//                    new MessageCreateDto(user.getId(), UUID.randomUUID(), "안녕하세요.", List.of()));
+//            System.out.println("메시지 생성: " + message.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 생성 실패: " + e.getMessage());
+//        }
+//
+//        // 조회
+//
+//        // 채널 ID로 조회
+//        List<Message> foundMessagesByChannelId = messageService.findAllByChannelId(privateChannel.getId());
+//        System.out.println("채널 내 메시지 조회(다건): " + foundMessagesByChannelId.size());
+//
+//        // 유저 ID로 조회
+//        List<Message> foundMessagesByAuthorId = messageService.findAllByAuthorId(user.getId());
+//        System.out.println("유저가 쓴 메시지 조회(다건): " + foundMessagesByAuthorId.size());
+//
+//        try {
+//            Message message = messageService.create(
+//                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 조회 테스트", List.of()));
+//            Message foundMessage = messageService.findById(message.getId());
+//            System.out.println("메시지 조회(단건): " + foundMessage.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 조회(단건) 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 ID 조회
+//        try {
+//            Message foundMessage = messageService.findById(UUID.randomUUID());
+//            System.out.println("메시지 조회(단건): " + foundMessage.getId());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 조회(단건) 실패: " + e.getMessage());
+//        }
+//
+//        // 수정
+//        try {
+//            Message message = messageService.create(
+//                    new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 수정 테스트", List.of()));
+//            Message updatedMessage = messageService.update(new MessageUpdateDto(message.getId(), "메시지 수정 성공 테스트입니다."));
+//            System.out.println("메시지 수정: " + updatedMessage.getContent());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 수정 실패: " + e.getMessage());
+//        }
+//
+//        // 존재하지 않는 ID로 수정
+//        try {
+//            Message updatedMessage = messageService.update(
+//                    new MessageUpdateDto(UUID.randomUUID(), "메시지 수정 실패 테스트입니다."));
+//            System.out.println("메시지 수정: " + updatedMessage.getContent());
+//        } catch (RuntimeException e) {
+//            System.out.println("메시지 수정 실패: " + e.getMessage());
+//        }
+//
+//        // 삭제
+//        Message deletedMessage = messageService.create(
+//                new MessageCreateDto(user.getId(), privateChannel.getId(), "메시지 삭제 테스트", List.of()));
+//        List<Message> foundMessagesBeforeDelete = messageService.findAllByChannelId(privateChannel.getId());
+//        System.out.println("메시지 삭제 전: " + foundMessagesBeforeDelete.size());
+//        messageService.delete(deletedMessage.getId());
+//        List<Message> foundMessagesAfterDelete = messageService.findAllByChannelId(privateChannel.getId());
+//        System.out.println("메시지 삭제: " + foundMessagesAfterDelete.size());
+//    }
     public static void main(String[] args) {
         ConfigurableApplicationContext context = SpringApplication.run(DiscodeitApplication.class, args);
 

--- a/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.dto.auth.AuthLoginDto;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth/login")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @RequestMapping(method = RequestMethod.POST)
+    public ResponseEntity<BaseResponseDto> createUser(@RequestBody AuthLoginDto authLoginDto) {
+        User user = authService.login(authLoginDto);
+        return ResponseEntity.ok(BaseResponseDto.success(user.getId() + " 유저 로그인이 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/BynaryContentController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/BynaryContentController.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,13 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/binary-content")
+@RequestMapping("/api/binaryContent")
 public class BynaryContentController {
 
     private final BinaryContentService binaryContentService;
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-    public ResponseEntity<BinaryContent> getBinaryContentById(@PathVariable("id") UUID binaryContentId) {
+    @RequestMapping(value = "/find", method = RequestMethod.GET)
+    public ResponseEntity<BinaryContent> getBinaryContentById(@RequestParam UUID binaryContentId) {
         return ResponseEntity.ok(binaryContentService.findById(binaryContentId));
     }
 

--- a/src/main/java/com/sprint/mission/discodeit/controller/BynaryContentController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/BynaryContentController.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.service.BinaryContentService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/binary-content")
+public class BynaryContentController {
+
+    private final BinaryContentService binaryContentService;
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+    public ResponseEntity<BinaryContent> getBinaryContentById(@PathVariable("id") UUID binaryContentId) {
+        return ResponseEntity.ok(binaryContentService.findById(binaryContentId));
+    }
+
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity<List<BinaryContent>> getBinaryContents(@RequestParam List<UUID> binaryContentIds) {
+        System.out.println(binaryContentIds);
+        return ResponseEntity.ok(binaryContentService.findAllByIdIn(binaryContentIds));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
@@ -1,0 +1,55 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelCreatePrivateDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelCreatePublicDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelUpdateDto;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.service.ChannelService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/channels")
+public class ChannelController {
+
+    private final ChannelService channelService;
+
+    @RequestMapping(value = "/public", method = RequestMethod.POST)
+    public ResponseEntity<BaseResponseDto> createUser(@RequestBody ChannelCreatePublicDto channelCreatePublicDto) {
+        Channel channel = channelService.createPublic(channelCreatePublicDto);
+        return ResponseEntity.ok(BaseResponseDto.success(channel.getId() + " 채널 생성이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/private", method = RequestMethod.POST)
+    public ResponseEntity<BaseResponseDto> createUser(@RequestBody ChannelCreatePrivateDto channelCreatePrivateDto) {
+        Channel channel = channelService.createPrivate(channelCreatePrivateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(channel.getId() + " 채널 생성이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
+    public ResponseEntity<BaseResponseDto> updateChannel(@RequestBody ChannelUpdateDto channelUpdateDto) {
+        Channel channel = channelService.update(channelUpdateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(channel.getId() + " 채널 변경이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    public ResponseEntity<BaseResponseDto> deleteChannel(@PathVariable("id") UUID channelId) {
+        channelService.delete(channelId);
+        return ResponseEntity.ok(BaseResponseDto.success(channelId + " 채널 삭제가 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/user/{id}", method = RequestMethod.GET)
+    public ResponseEntity<List<ChannelDto>> getChannelByUserId(@PathVariable("id") UUID userId) {
+        return ResponseEntity.ok(channelService.findAllByUserId(userId));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
@@ -1,19 +1,25 @@
 package com.sprint.mission.discodeit.controller;
 
 import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentCreateDto;
 import com.sprint.mission.discodeit.dto.message.MessageCreateDto;
 import com.sprint.mission.discodeit.dto.message.MessageUpdateDto;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.service.MessageService;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,9 +28,29 @@ public class MessageController {
 
     private final MessageService messageService;
 
-    @RequestMapping(method = RequestMethod.POST)
-    public ResponseEntity<BaseResponseDto> createMessage(@RequestBody MessageCreateDto messageCreateDto) {
-        Message message = messageService.create(messageCreateDto);
+    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<BaseResponseDto> createMessage(@RequestPart("message") MessageCreateDto messageCreateDto,
+                                                         @RequestPart(value = "files", required = false) List<MultipartFile> files) {
+        List<BinaryContentCreateDto> binaryDtos = new ArrayList<>();
+
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                try {
+                    BinaryContentCreateDto dto = new BinaryContentCreateDto(
+                            file.getOriginalFilename(),
+                            file.getSize(),
+                            file.getContentType(),
+                            file.getBytes()
+                    );
+                    binaryDtos.add(dto);
+                } catch (IOException e) {
+                    return ResponseEntity.internalServerError()
+                            .body(BaseResponseDto.failure("첨부파일 처리 중 오류 발생: " + e.getMessage()));
+                }
+            }
+        }
+
+        Message message = messageService.create(messageCreateDto, binaryDtos);
         return ResponseEntity.ok(BaseResponseDto.success(message.getId() + " 메시지 등록이 완료되었습니다."));
     }
 

--- a/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
@@ -1,0 +1,47 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.dto.message.MessageCreateDto;
+import com.sprint.mission.discodeit.dto.message.MessageUpdateDto;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.service.MessageService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/messages")
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @RequestMapping(method = RequestMethod.POST)
+    public ResponseEntity<BaseResponseDto> createMessage(@RequestBody MessageCreateDto messageCreateDto) {
+        Message message = messageService.create(messageCreateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(message.getId() + " 메시지 등록이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
+    public ResponseEntity<BaseResponseDto> updateMessage(@RequestBody MessageUpdateDto messageUpdateDto) {
+        Message message = messageService.update(messageUpdateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(message.getId() + " 메시지 변경이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    public ResponseEntity<BaseResponseDto> deleteMessage(@PathVariable("id") UUID messageId) {
+        messageService.delete(messageId);
+        return ResponseEntity.ok(BaseResponseDto.success(messageId + " 메시지 삭제가 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/channel/{id}", method = RequestMethod.GET)
+    public ResponseEntity<List<Message>> getMessages(@PathVariable("id") UUID channelId) {
+        return ResponseEntity.ok(messageService.findAllByChannelId(channelId));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
@@ -1,0 +1,41 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.dto.readStatus.ReadStatusCreateDto;
+import com.sprint.mission.discodeit.dto.readStatus.ReadStatusUpdateDto;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.service.ReadStatusService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/read-status")
+public class ReadStatusController {
+
+    private final ReadStatusService readStatusService;
+
+    @RequestMapping(method = RequestMethod.POST)
+    public ResponseEntity<BaseResponseDto> createReadStatus(@RequestBody ReadStatusCreateDto readStatusCreateDto) {
+        ReadStatus readStatus = readStatusService.create(readStatusCreateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(readStatus.getId() + " ReadStatus 등록이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
+    public ResponseEntity<BaseResponseDto> updateReadStatus(@RequestBody ReadStatusUpdateDto readStatusUpdateDto) {
+        ReadStatus readStatus = readStatusService.update(readStatusUpdateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(readStatus.getId() + " ReadStatus 변경이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/user/{id}", method = RequestMethod.GET)
+    public ResponseEntity<List<ReadStatus>> getReadStatuss(@PathVariable("id") UUID userId) {
+        return ResponseEntity.ok(readStatusService.findAllByUserId(userId));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
@@ -1,0 +1,60 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.dto.user.UserCreateDto;
+import com.sprint.mission.discodeit.dto.user.UserDto;
+import com.sprint.mission.discodeit.dto.user.UserUpdateDto;
+import com.sprint.mission.discodeit.dto.userStatus.UserStatusUpdateByUserIdDto;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.UserStatusService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+    private final UserStatusService userStatusService;
+
+    @RequestMapping(method = RequestMethod.POST)
+    public ResponseEntity<BaseResponseDto> createUser(@RequestBody UserCreateDto userCreateDto) {
+        User user = userService.create(userCreateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(user.getId() + " 유저 등록이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
+    public ResponseEntity<BaseResponseDto> updateUser(@RequestBody UserUpdateDto userUpdateDto) {
+        User user = userService.update(userUpdateDto);
+        return ResponseEntity.ok(BaseResponseDto.success(user.getId() + " 유저 변경이 완료되었습니다."));
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    public ResponseEntity<BaseResponseDto> deleteUser(@PathVariable("id") UUID userId) {
+        userService.delete(userId);
+        return ResponseEntity.ok(BaseResponseDto.success(userId + " 유저 삭제가 완료되었습니다."));
+    }
+
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity<List<UserDto>> getUsers() {
+        return ResponseEntity.ok(userService.findAll());
+    }
+
+    @RequestMapping(value = "{id}/status", method = RequestMethod.PUT)
+    public ResponseEntity<BaseResponseDto> updateUserStatus(@PathVariable("id") UUID userId) {
+        UserStatusUpdateByUserIdDto userStatusUpdateByUserIdDto = new UserStatusUpdateByUserIdDto(userId,
+                Instant.now());
+        userStatusService.updateByUserId(userStatusUpdateByUserIdDto);
+        return ResponseEntity.ok(BaseResponseDto.success(userId + " 유저의 상태가 업데이트 되었습니다."));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
@@ -71,7 +71,7 @@ public class UserController {
         return ResponseEntity.ok(BaseResponseDto.success(userId + " 유저 삭제가 완료되었습니다."));
     }
 
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(value = "/findAll", method = RequestMethod.GET)
     public ResponseEntity<List<UserDto>> getUsers() {
         return ResponseEntity.ok(userService.findAll());
     }

--- a/src/main/java/com/sprint/mission/discodeit/dto/BaseResponseDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/BaseResponseDto.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.dto;
+
+public record BaseResponseDto(
+        boolean success,
+        String message
+) {
+    public static BaseResponseDto success(String message) {
+        return new BaseResponseDto(true, message);
+    }
+
+    public static BaseResponseDto failure(String message) {
+        return new BaseResponseDto(false, message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/binaryContent/BinaryContentCreateDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/binaryContent/BinaryContentCreateDto.java
@@ -1,6 +1,8 @@
 package com.sprint.mission.discodeit.dto.binaryContent;
 
 public record BinaryContentCreateDto(
-        byte[] binaryImage
+        String fileName,
+        String contentType,
+        byte[] bytesImage
 ) {
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/binaryContent/BinaryContentCreateDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/binaryContent/BinaryContentCreateDto.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.dto.binaryContent;
 
 public record BinaryContentCreateDto(
         String fileName,
+        Long size,
         String contentType,
         byte[] bytesImage
 ) {

--- a/src/main/java/com/sprint/mission/discodeit/dto/channel/ChannelDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/channel/ChannelDto.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-public record ChannelResponseDto(
+public record ChannelDto(
         UUID id,
         String name,
         String description,
@@ -14,7 +14,7 @@ public record ChannelResponseDto(
         Instant lastMessageAt,
         List<UUID> userIds
 ) {
-    public ChannelResponseDto(Channel channel, Instant lastMessageAt, List<UUID> userIds) {
+    public ChannelDto(Channel channel, Instant lastMessageAt, List<UUID> userIds) {
         this(channel.getId(), channel.getName(), channel.getDescription(), channel.getType(), lastMessageAt, userIds);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/message/MessageCreateDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/message/MessageCreateDto.java
@@ -1,12 +1,10 @@
 package com.sprint.mission.discodeit.dto.message;
 
-import java.util.List;
 import java.util.UUID;
 
 public record MessageCreateDto(
         UUID authorId,
         UUID channelId,
-        String content,
-        List<UUID> attachmentIds
+        String content
 ) {
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/readStatus/ReadStatusDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/readStatus/ReadStatusDto.java
@@ -3,7 +3,7 @@ package com.sprint.mission.discodeit.dto.readStatus;
 import java.time.Instant;
 import java.util.UUID;
 
-public record ReadStatusResponseDto(
+public record ReadStatusDto(
         UUID userId,
         UUID channelId,
         Instant lastReadAt

--- a/src/main/java/com/sprint/mission/discodeit/dto/user/UserCreateDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/user/UserCreateDto.java
@@ -1,12 +1,8 @@
 package com.sprint.mission.discodeit.dto.user;
 
-import java.util.Optional;
-import java.util.UUID;
-
 public record UserCreateDto(
         String username,
         String password,
-        String email,
-        Optional<UUID> profileId
+        String email
 ) {
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/user/UserDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/user/UserDto.java
@@ -4,7 +4,7 @@ import com.sprint.mission.discodeit.entity.User;
 import java.time.Instant;
 import java.util.UUID;
 
-public record UserResponseDto(
+public record UserDto(
         UUID id,
         String username,
         String email,
@@ -13,7 +13,7 @@ public record UserResponseDto(
         Instant updatedAt,
         boolean isActive
 ) {
-    public UserResponseDto(User user, boolean isActive) {
+    public UserDto(User user, boolean isActive) {
         this(user.getId(), user.getUsername(), user.getEmail(), user.getProfileId(),
                 user.getCreatedAt(), user.getUpdatedAt(), isActive);
     }

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -10,11 +10,17 @@ public class BinaryContent implements Serializable {
     private static final long serialVersionUID = 1L;
     private final UUID id;
     private final Instant createdAt;
+    private String fileName;
+    private Long size;
+    private String contentType;
     private final byte[] binaryImage;
 
-    public BinaryContent(byte[] binaryImage) {
+    public BinaryContent(String fileName, Long size, String contentType, byte[] binaryImage) {
         this.id = UUID.randomUUID();
         this.createdAt = Instant.now();
+        this.fileName = fileName;
+        this.size = size;
+        this.contentType = contentType;
         this.binaryImage = binaryImage;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -17,6 +17,14 @@ public class Channel extends BaseEntity implements Serializable {
         this.description = description;
     }
 
+    public static Channel createPrivate() {
+        return new Channel(ChannelType.PRIVATE, null, null);
+    }
+
+    public static Channel createPublic(String name, String description) {
+        return new Channel(ChannelType.PUBLIC, name, description);
+    }
+
     public void update(String newName, String newDescription) {
         boolean anyValueUpdated = false;
         if (newName != null && !newName.equals(this.name)) {

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -13,12 +13,12 @@ public class User extends BaseEntity implements Serializable {
 
     private UUID profileId;
 
-    public User(String username, String email, String password) {
+    public User(String username, String email, String password, UUID profileId) {
         super();
         this.username = username;
         this.email = email;
         this.password = password;
-        this.profileId = null;
+        this.profileId = profileId;
     }
 
     public void update(String newUsername, String newEmail, String newPassword, UUID newProfileId) {

--- a/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -34,7 +34,7 @@ public class UserStatus extends BaseEntity implements Serializable {
 
     public boolean isActive() {
         Instant now = Instant.now();
-        Duration duration = Duration.between(now, this.lastActiveAt);
+        Duration duration = Duration.between(this.lastActiveAt, now);
 
         return duration.compareTo(MAX_ACTIVE_MINUTES) < 0; // 5분 이내면 true;
     }

--- a/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 public class UserStatus extends BaseEntity implements Serializable {
     private static final long serialVersionUID = 1L;
+    private static final Duration MAX_ACTIVE_MINUTES = Duration.ofMinutes(5);
     private final UUID userId;
 
     private Instant lastActiveAt;
@@ -33,9 +34,8 @@ public class UserStatus extends BaseEntity implements Serializable {
 
     public boolean isActive() {
         Instant now = Instant.now();
-        Instant lastActive = this.lastActiveAt;
-        Duration duration = Duration.between(now, lastActive);
+        Duration duration = Duration.between(now, this.lastActiveAt);
 
-        return duration.getSeconds() < 300; // 5분 이내면 true;
+        return duration.compareTo(MAX_ACTIVE_MINUTES) < 0; // 5분 이내면 true;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.exception.handler;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<BaseResponseDto> handleRuntimeException(RuntimeException e) {
+        return ResponseEntity.badRequest().body(BaseResponseDto.failure(e.getMessage()));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/UserExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/UserExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.sprint.mission.discodeit.exception.handler;
+
+import com.sprint.mission.discodeit.dto.BaseResponseDto;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserEmailAlreadyExistsException;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNameAlreadyExistsException;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class UserExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<BaseResponseDto> handleUserNotFound(UserNotFoundException e) {
+        return ResponseEntity.status(404).body(BaseResponseDto.failure("유저 오류: " + e.getMessage()));
+    }
+
+    @ExceptionHandler(UserEmailAlreadyExistsException.class)
+    public ResponseEntity<BaseResponseDto> handleEmailExists(UserEmailAlreadyExistsException e) {
+        return ResponseEntity.badRequest().body(BaseResponseDto.failure("이메일 오류: " + e.getMessage()));
+    }
+
+    @ExceptionHandler(UserNameAlreadyExistsException.class)
+    public ResponseEntity<BaseResponseDto> handleNameExists(UserNameAlreadyExistsException e) {
+        return ResponseEntity.badRequest().body(BaseResponseDto.failure("이름 오류: " + e.getMessage()));
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/binaryContent/BinaryContentNotFoundException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/binaryContent/BinaryContentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.binaryContent;
+
+public class BinaryContentNotFoundException extends RuntimeException {
+    public BinaryContentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/channel/ChannelNotFoundException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/channel/ChannelNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.channel;
+
+public class ChannelNotFoundException extends RuntimeException {
+    public ChannelNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/channel/PrivateChannelUpdateException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/channel/PrivateChannelUpdateException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.channel;
+
+public class PrivateChannelUpdateException extends RuntimeException {
+    public PrivateChannelUpdateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/channel/UserEmailAlreadyExistsException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/channel/UserEmailAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.channel;
+
+public class UserEmailAlreadyExistsException extends RuntimeException {
+    public UserEmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/message/MessageNotFoundException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/message/MessageNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.message;
+
+public class MessageNotFoundException extends RuntimeException {
+    public MessageNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/readStatus/ReadStatusAlreadyExistsException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/readStatus/ReadStatusAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.readStatus;
+
+public class ReadStatusAlreadyExistsException extends RuntimeException {
+    public ReadStatusAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/readStatus/ReadStatusNotFoundException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/readStatus/ReadStatusNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.readStatus;
+
+public class ReadStatusNotFoundException extends RuntimeException {
+    public ReadStatusNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/user/UserEmailAlreadyExistsException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/user/UserEmailAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.user;
+
+public class UserEmailAlreadyExistsException extends RuntimeException {
+    public UserEmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/user/UserNameAlreadyExistsException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/user/UserNameAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.user;
+
+public class UserNameAlreadyExistsException extends RuntimeException {
+    public UserNameAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/user/UserNotFoundException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/handler/custom/user/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.exception.handler.custom.user;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -2,7 +2,7 @@ package com.sprint.mission.discodeit.service;
 
 import com.sprint.mission.discodeit.dto.channel.ChannelCreatePrivateDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelCreatePublicDto;
-import com.sprint.mission.discodeit.dto.channel.ChannelResponseDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelUpdateDto;
 import com.sprint.mission.discodeit.entity.Channel;
 import java.util.List;
@@ -13,9 +13,9 @@ public interface ChannelService {
 
     Channel createPublic(ChannelCreatePublicDto channelCreatePublicDto);
 
-    ChannelResponseDto findById(UUID channelId);
+    ChannelDto findById(UUID channelId);
 
-    List<ChannelResponseDto> findAllByUserId(UUID userId);
+    List<ChannelDto> findAllByUserId(UUID userId);
 
     Channel update(ChannelUpdateDto channelUpdateDto);
 

--- a/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
@@ -1,5 +1,6 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentCreateDto;
 import com.sprint.mission.discodeit.dto.message.MessageCreateDto;
 import com.sprint.mission.discodeit.dto.message.MessageUpdateDto;
 import com.sprint.mission.discodeit.entity.Message;
@@ -7,7 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface MessageService {
-    Message create(MessageCreateDto messageCreateDto);
+    Message create(MessageCreateDto messageCreateDto, List<BinaryContentCreateDto> binaryContentCreateDtos);
 
     Message findById(UUID messageId);
 

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -1,7 +1,7 @@
 package com.sprint.mission.discodeit.service;
 
 import com.sprint.mission.discodeit.dto.user.UserCreateDto;
-import com.sprint.mission.discodeit.dto.user.UserResponseDto;
+import com.sprint.mission.discodeit.dto.user.UserDto;
 import com.sprint.mission.discodeit.dto.user.UserUpdateDto;
 import com.sprint.mission.discodeit.entity.User;
 import java.util.List;
@@ -10,9 +10,9 @@ import java.util.UUID;
 public interface UserService {
     User create(UserCreateDto userCreateDto);
 
-    UserResponseDto findById(UUID userId);
+    UserDto findById(UUID userId);
 
-    List<UserResponseDto> findAll();
+    List<UserDto> findAll();
 
     User update(UserUpdateDto userUpdateDto);
 

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -1,14 +1,16 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentCreateDto;
 import com.sprint.mission.discodeit.dto.user.UserCreateDto;
 import com.sprint.mission.discodeit.dto.user.UserDto;
 import com.sprint.mission.discodeit.dto.user.UserUpdateDto;
 import com.sprint.mission.discodeit.entity.User;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserService {
-    User create(UserCreateDto userCreateDto);
+    User create(UserCreateDto userCreateDto, Optional<BinaryContentCreateDto> binaryContentCreateDto);
 
     UserDto findById(UUID userId);
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
@@ -3,11 +3,11 @@ package com.sprint.mission.discodeit.service.basic;
 import com.sprint.mission.discodeit.dto.auth.AuthLoginDto;
 import com.sprint.mission.discodeit.dto.userStatus.UserStatusUpdateByUserIdDto;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNotFoundException;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.AuthService;
 import com.sprint.mission.discodeit.service.UserStatusService;
 import java.time.Instant;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,7 +26,7 @@ public class BasicAuthService implements AuthService {
                 .orElse(null);
 
         if (foundUser == null) {
-            throw new NoSuchElementException("로그인 실패: 유저를 찾을 수 없습니다.");
+            throw new UserNotFoundException("로그인 실패: 유저를 찾을 수 없습니다.");
         }
 
         UserStatusUpdateByUserIdDto userStatusUpdateByUserIdDto = new UserStatusUpdateByUserIdDto(foundUser.getId(),

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
@@ -1,9 +1,12 @@
 package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.auth.AuthLoginDto;
+import com.sprint.mission.discodeit.dto.userStatus.UserStatusUpdateByUserIdDto;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.AuthService;
+import com.sprint.mission.discodeit.service.UserStatusService;
+import java.time.Instant;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class BasicAuthService implements AuthService {
 
     private final UserRepository userRepository;
+    private final UserStatusService userStatusService;
 
     @Override
     public User login(AuthLoginDto authLoginDto) {
@@ -24,6 +28,10 @@ public class BasicAuthService implements AuthService {
         if (foundUser == null) {
             throw new NoSuchElementException("로그인 실패: 유저를 찾을 수 없습니다.");
         }
+
+        UserStatusUpdateByUserIdDto userStatusUpdateByUserIdDto = new UserStatusUpdateByUserIdDto(foundUser.getId(),
+                Instant.now());
+        userStatusService.updateByUserId(userStatusUpdateByUserIdDto);
 
         return foundUser;
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -2,10 +2,10 @@ package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentCreateDto;
 import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.exception.handler.custom.binaryContent.BinaryContentNotFoundException;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.service.BinaryContentService;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,7 @@ public class BasicBinaryContentService implements BinaryContentService {
         BinaryContent binaryContent = new BinaryContent(binaryContentCreateDto.fileName(),
                 (long) binaryContentCreateDto.bytesImage().length,
                 binaryContentCreateDto.contentType(), binaryContentCreateDto.bytesImage());
-        
+
         return binaryContentRepository.save(binaryContent);
     }
 
@@ -29,7 +29,7 @@ public class BasicBinaryContentService implements BinaryContentService {
     public BinaryContent findById(UUID binaryContentId) {
         BinaryContent binaryContent = binaryContentRepository.findById(binaryContentId);
         if (binaryContent == null) {
-            throw new NoSuchElementException(binaryContentId + "binary content를 찾을 수 없습니다.");
+            throw new BinaryContentNotFoundException(binaryContentId + " binary content를 찾을 수 없습니다.");
         }
 
         return binaryContent;

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -18,7 +18,10 @@ public class BasicBinaryContentService implements BinaryContentService {
 
     @Override
     public BinaryContent create(BinaryContentCreateDto binaryContentCreateDto) {
-        BinaryContent binaryContent = new BinaryContent(binaryContentCreateDto.binaryImage());
+        BinaryContent binaryContent = new BinaryContent(binaryContentCreateDto.fileName(),
+                (long) binaryContentCreateDto.bytesImage().length,
+                binaryContentCreateDto.contentType(), binaryContentCreateDto.bytesImage());
+        
         return binaryContentRepository.save(binaryContent);
     }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -9,6 +9,8 @@ import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.exception.handler.custom.channel.ChannelNotFoundException;
+import com.sprint.mission.discodeit.exception.handler.custom.channel.PrivateChannelUpdateException;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
@@ -16,7 +18,6 @@ import com.sprint.mission.discodeit.service.ReadStatusService;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +56,7 @@ public class BasicChannelService implements ChannelService {
                 );
 
         if (isExistChannel) {
-            throw new RuntimeException(channelCreatePublicDto.name() + " 채널은 이미 존재합니다.");
+            throw new PrivateChannelUpdateException(channelCreatePublicDto.name() + " 채널은 이미 존재합니다.");
         }
 
         Channel newChannel = Channel.createPublic(channelCreatePublicDto.name(), channelCreatePublicDto.description());
@@ -69,7 +70,7 @@ public class BasicChannelService implements ChannelService {
         Channel channel = channelRepository.findById(channelId);
 
         if (channel == null) {
-            throw new NoSuchElementException(channelId + " 채널을 찾을 수 없습니다.");
+            throw new ChannelNotFoundException(channelId + " 채널을 찾을 수 없습니다.");
         }
 
         Instant lastMessageAt = messageRepository.findAllByChannelId(channel.getId())
@@ -133,11 +134,11 @@ public class BasicChannelService implements ChannelService {
         Channel channel = channelRepository.findById(channelUpdateDto.id());
 
         if (channel == null) {
-            throw new RuntimeException(channelUpdateDto.id() + " 채널은 존재하지 않아 수정할 수 없습니다.");
+            throw new ChannelNotFoundException(channelUpdateDto.id() + " 채널은 존재하지 않아 수정할 수 없습니다.");
         }
 
         if (channel.getType().equals(ChannelType.PRIVATE)) {
-            throw new IllegalArgumentException("Private 채널은 수정할 수 없습니다.");
+            throw new PrivateChannelUpdateException("Private 채널은 수정할 수 없습니다.");
         }
 
         channel.update(channelUpdateDto.newName(), channelUpdateDto.newDescription());

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -32,7 +32,7 @@ public class BasicChannelService implements ChannelService {
     @Override
     public Channel createPrivate(ChannelCreatePrivateDto channelCreatePrivateDto) {
 
-        Channel newChannel = new Channel(ChannelType.PRIVATE, null, null);
+        Channel newChannel = Channel.createPrivate();
         channelRepository.save(newChannel);
 
         channelCreatePrivateDto.users().forEach(user -> {
@@ -57,8 +57,7 @@ public class BasicChannelService implements ChannelService {
             throw new RuntimeException(channelCreatePublicDto.name() + " 채널은 이미 존재합니다.");
         }
 
-        Channel newChannel = new Channel(ChannelType.PUBLIC, channelCreatePublicDto.name(),
-                channelCreatePublicDto.description());
+        Channel newChannel = Channel.createPublic(channelCreatePublicDto.name(), channelCreatePublicDto.description());
         channelRepository.save(newChannel);
 
         return newChannel;

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -2,7 +2,7 @@ package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.channel.ChannelCreatePrivateDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelCreatePublicDto;
-import com.sprint.mission.discodeit.dto.channel.ChannelResponseDto;
+import com.sprint.mission.discodeit.dto.channel.ChannelDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelUpdateDto;
 import com.sprint.mission.discodeit.dto.readStatus.ReadStatusCreateDto;
 import com.sprint.mission.discodeit.entity.Channel;
@@ -65,7 +65,7 @@ public class BasicChannelService implements ChannelService {
     }
 
     @Override
-    public ChannelResponseDto findById(UUID channelId) {
+    public ChannelDto findById(UUID channelId) {
         Channel channel = channelRepository.findById(channelId);
 
         if (channel == null) {
@@ -85,11 +85,11 @@ public class BasicChannelService implements ChannelService {
                         .toList()
                 : null;
 
-        return new ChannelResponseDto(channel, lastMessageAt, userIds);
+        return new ChannelDto(channel, lastMessageAt, userIds);
     }
 
     @Override
-    public List<ChannelResponseDto> findAllByUserId(UUID userId) {
+    public List<ChannelDto> findAllByUserId(UUID userId) {
         List<Channel> channels = channelRepository.findAll();
         List<UUID> joinedChannelIds = readStatusService.findAllByUserId(userId).stream()
                 .map(ReadStatus::getChannelId)
@@ -114,7 +114,7 @@ public class BasicChannelService implements ChannelService {
                                     .toList()
                             : null;
 
-                    return new ChannelResponseDto(channel, lastMessageAt, userIds);
+                    return new ChannelDto(channel, lastMessageAt, userIds);
                 })
                 .toList();
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -72,7 +72,7 @@ public class BasicMessageService implements MessageService {
         Message message = findById(messageId);
         List<UUID> attachmentIds = message.getAttachmentIds();
 
-        if (attachmentIds != null) {
+        if (!attachmentIds.isEmpty()) {
             attachmentIds.forEach(binaryContentRepository::delete);
         }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -3,13 +3,15 @@ package com.sprint.mission.discodeit.service.basic;
 import com.sprint.mission.discodeit.dto.message.MessageCreateDto;
 import com.sprint.mission.discodeit.dto.message.MessageUpdateDto;
 import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.exception.handler.custom.channel.ChannelNotFoundException;
+import com.sprint.mission.discodeit.exception.handler.custom.message.MessageNotFoundException;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNotFoundException;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.MessageService;
 import com.sprint.mission.discodeit.service.UserService;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,8 +30,10 @@ public class BasicMessageService implements MessageService {
         try {
             userService.findById(messageCreateDto.authorId());
             channelService.findById(messageCreateDto.channelId());
-        } catch (NoSuchElementException e) {
-            throw new RuntimeException("Message 생성 실패: " + e.getMessage());
+        } catch (UserNotFoundException e) {
+            throw new UserNotFoundException("Message 생성 실패: " + e.getMessage());
+        } catch (ChannelNotFoundException e) {
+            throw new ChannelNotFoundException("Message 생성 실패: " + e.getMessage());
         }
 
         Message newMessage = new Message(messageCreateDto.authorId(), messageCreateDto.channelId(),
@@ -43,7 +47,7 @@ public class BasicMessageService implements MessageService {
         Message message = messageRepository.findById(messageId);
 
         if (message == null) {
-            throw new NoSuchElementException(messageId + " 메시지를 찾을 수 없습니다.");
+            throw new MessageNotFoundException(messageId + " 메시지를 찾을 수 없습니다.");
         }
 
         return message;

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -3,12 +3,15 @@ package com.sprint.mission.discodeit.service.basic;
 import com.sprint.mission.discodeit.dto.readStatus.ReadStatusCreateDto;
 import com.sprint.mission.discodeit.dto.readStatus.ReadStatusUpdateDto;
 import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.exception.handler.custom.channel.ChannelNotFoundException;
+import com.sprint.mission.discodeit.exception.handler.custom.readStatus.ReadStatusAlreadyExistsException;
+import com.sprint.mission.discodeit.exception.handler.custom.readStatus.ReadStatusNotFoundException;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNotFoundException;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.ReadStatusService;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,18 +28,18 @@ public class BasicReadStatusService implements ReadStatusService {
     public ReadStatus create(ReadStatusCreateDto readStatusCreateDto) {
         boolean isExistUser = userRepository.findById(readStatusCreateDto.userId()) != null;
         if (!isExistUser) {
-            throw new NoSuchElementException(readStatusCreateDto.userId() + " 유저를 찾을 수 없습니다.");
+            throw new UserNotFoundException(readStatusCreateDto.userId() + " 유저를 찾을 수 없습니다.");
         }
 
         boolean isExistChannel = channelRepository.findById(readStatusCreateDto.channelId()) != null;
         if (!isExistChannel) {
-            throw new NoSuchElementException(readStatusCreateDto.channelId() + " 채널을 찾을 수 없습니다.");
+            throw new ChannelNotFoundException(readStatusCreateDto.channelId() + " 채널을 찾을 수 없습니다.");
         }
 
         boolean isExistReadStatus = readStatusRepository.findAllByChannelId(readStatusCreateDto.channelId()).stream()
                 .anyMatch(readStatus -> readStatus.getUserId().equals(readStatusCreateDto.userId()));
         if (isExistReadStatus) {
-            throw new RuntimeException(
+            throw new ReadStatusAlreadyExistsException(
                     readStatusCreateDto.userId() + " 유저는 이미 " + readStatusCreateDto.channelId() + " 채널을 읽었습니다.");
         }
 
@@ -51,7 +54,7 @@ public class BasicReadStatusService implements ReadStatusService {
         ReadStatus readStatus = readStatusRepository.findById(id);
 
         if (readStatus == null) {
-            throw new NoSuchElementException(id + " 읽은 상태를 찾을 수 없습니다.");
+            throw new ReadStatusNotFoundException(id + " 읽은 상태를 찾을 수 없습니다.");
         }
 
         return readStatus;
@@ -77,7 +80,7 @@ public class BasicReadStatusService implements ReadStatusService {
         ReadStatus readStatus = findById(readStatusUpdateDto.id());
         readStatus.update(readStatusUpdateDto.newLastReadAt());
 
-        return readStatus;
+        return readStatusRepository.save(readStatus);
     }
 
     @Override

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -7,13 +7,15 @@ import com.sprint.mission.discodeit.dto.userStatus.UserStatusCreateDto;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserEmailAlreadyExistsException;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNameAlreadyExistsException;
+import com.sprint.mission.discodeit.exception.handler.custom.user.UserNotFoundException;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.UserService;
 import com.sprint.mission.discodeit.service.UserStatusService;
 import java.time.Instant;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,12 +34,12 @@ public class BasicUserService implements UserService {
 
         boolean isEmailExist = users.stream().anyMatch(user -> user.getEmail().equals(userCreateDto.email()));
         if (isEmailExist) {
-            throw new RuntimeException(userCreateDto.email() + " 이메일은 이미 가입되었습니다.");
+            throw new UserEmailAlreadyExistsException(userCreateDto.email() + " 이메일은 이미 가입되었습니다.");
         }
 
         boolean isNameExist = users.stream().anyMatch(user -> user.getUsername().equals(userCreateDto.username()));
         if (isNameExist) {
-            throw new RuntimeException(userCreateDto.username() + " 이름은 이미 가입되었습니다.");
+            throw new UserNameAlreadyExistsException(userCreateDto.username() + " 이름은 이미 가입되었습니다.");
         }
 
         User newUser = new User(userCreateDto.username(), userCreateDto.email(), userCreateDto.password());
@@ -52,7 +54,7 @@ public class BasicUserService implements UserService {
         User user = userRepository.findById(userId);
 
         if (user == null) {
-            throw new NoSuchElementException(userId + " 유저를 찾을 수 없습니다.");
+            throw new UserNotFoundException(userId + " 유저를 찾을 수 없습니다.");
         }
 
         UserStatus userStatus = userStatusService.findById(user.getId());
@@ -75,14 +77,14 @@ public class BasicUserService implements UserService {
                 user -> user.getEmail().equals(userUpdateDto.newEmail()));
 
         if (isEmailExist) {
-            throw new RuntimeException(userUpdateDto.newEmail() + " 이메일은 이미 존재하여 수정할 수 없습니다.");
+            throw new UserEmailAlreadyExistsException(userUpdateDto.newEmail() + " 이메일은 이미 존재하여 수정할 수 없습니다.");
         }
 
         boolean isNameExist = users.stream().anyMatch(
                 user -> user.getUsername().equals(userUpdateDto.newUsername()));
 
         if (isNameExist) {
-            throw new RuntimeException(userUpdateDto.newEmail() + " 유저는 이미 존재하여 수정할 수 없습니다.");
+            throw new UserNameAlreadyExistsException(userUpdateDto.newUsername() + " 유저는 이미 존재하여 수정할 수 없습니다.");
         }
 
         User user = userRepository.findById(userUpdateDto.id());

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -1,7 +1,7 @@
 package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.user.UserCreateDto;
-import com.sprint.mission.discodeit.dto.user.UserResponseDto;
+import com.sprint.mission.discodeit.dto.user.UserDto;
 import com.sprint.mission.discodeit.dto.user.UserUpdateDto;
 import com.sprint.mission.discodeit.dto.userStatus.UserStatusCreateDto;
 import com.sprint.mission.discodeit.entity.BinaryContent;
@@ -48,7 +48,7 @@ public class BasicUserService implements UserService {
     }
 
     @Override
-    public UserResponseDto findById(UUID userId) {
+    public UserDto findById(UUID userId) {
         User user = userRepository.findById(userId);
 
         if (user == null) {
@@ -57,14 +57,14 @@ public class BasicUserService implements UserService {
 
         UserStatus userStatus = userStatusService.findById(user.getId());
 
-        return new UserResponseDto(user, userStatus.isActive());
+        return new UserDto(user, userStatus.isActive());
     }
 
     @Override
-    public List<UserResponseDto> findAll() {
+    public List<UserDto> findAll() {
         return userRepository.findAll().stream().map(user -> {
             UserStatus userStatus = userStatusService.findById(user.getId());
-            return new UserResponseDto(user, userStatus.isActive());
+            return new UserDto(user, userStatus.isActive());
         }).toList();
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: discodeit
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 discodeit:
   repository:

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>사용자 목록</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="container">
+    <h1>사용자 목록</h1>
+    <div class="user-list" id="userList">
+        <!-- Users will be dynamically inserted here -->
+    </div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/script.js
+++ b/src/main/resources/static/script.js
@@ -1,0 +1,67 @@
+// API endpoints
+const API_BASE_URL = '/api';
+const ENDPOINTS = {
+    USERS: `${API_BASE_URL}/users/findAll`,
+    BINARY_CONTENT: `${API_BASE_URL}/binaryContent/find`
+};
+
+// Initialize the application
+document.addEventListener('DOMContentLoaded', () => {
+    fetchAndRenderUsers();
+});
+
+// Fetch users from the API
+async function fetchAndRenderUsers() {
+    try {
+        const response = await fetch(ENDPOINTS.USERS);
+        if (!response.ok) throw new Error('Failed to fetch users');
+        const users = await response.json();
+        renderUserList(users);
+    } catch (error) {
+        console.error('Error fetching users:', error);
+    }
+}
+
+// Fetch user profile image
+async function fetchUserProfile(profileId) {
+    try {
+        const response = await fetch(`${ENDPOINTS.BINARY_CONTENT}?binaryContentId=${profileId}`);
+        if (!response.ok) throw new Error('Failed to fetch profile');
+        const profile = await response.json();
+
+        // Convert base64 encoded bytes to data URL
+        return `data:${profile.contentType};base64,${profile.binaryImage}`;
+    } catch (error) {
+        console.error('Error fetching profile:', error);
+        return '/image/default-user.png'; // Fallback to default avatar
+    }
+}
+
+// Render user list
+async function renderUserList(users) {
+    const userListElement = document.getElementById('userList');
+    userListElement.innerHTML = ''; // Clear existing content
+
+    for (const user of users) {
+        const userElement = document.createElement('div');
+        userElement.className = 'user-item';
+
+        // Get profile image URL
+        const profileUrl = user.profileId ?
+            await fetchUserProfile(user.profileId) :
+            '/default-avatar.png';
+
+        userElement.innerHTML = `
+            <img src="${profileUrl}" alt="${user.username}" class="user-avatar">
+            <div class="user-info">
+                <div class="user-name">${user.username}</div>
+                <div class="user-email">${user.email}</div>
+            </div>
+            <div class="status-badge ${user.isActive ? 'online' : 'offline'}">
+                ${user.isActive ? '온라인' : '오프라인'}
+            </div>
+        `;
+
+        userListElement.appendChild(userElement);
+    }
+}

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -1,0 +1,95 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f0f2f5;
+    color: #333;
+}
+
+.container {
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 20px;
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 40px;
+    color: #2c3e50;
+    font-size: 32px;
+}
+
+.user-list {
+    background-color: white;
+    border-radius: 16px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    transition: box-shadow 0.3s ease;
+}
+
+.user-list:hover {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.user-item {
+    display: flex;
+    align-items: center;
+    padding: 24px 32px;
+    border-bottom: 1px solid #eaeaea;
+    transition: background-color 0.2s ease;
+}
+
+.user-item:hover {
+    background-color: #f9f9f9;
+}
+
+.user-item:last-child {
+    border-bottom: none;
+}
+
+.user-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    margin-right: 24px;
+    object-fit: cover;
+    border: 2px solid #ddd;
+}
+
+.user-info {
+    flex-grow: 1;
+}
+
+.user-name {
+    font-size: 20px;
+    font-weight: 600;
+    color: #2d3436;
+    margin-bottom: 6px;
+}
+
+.user-email {
+    font-size: 14px;
+    color: #636e72;
+}
+
+.status-badge {
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.online {
+    background-color: #2ecc71;
+    color: white;
+}
+
+.offline {
+    background-color: #bdc3c7;
+    color: white;
+}


### PR DESCRIPTION
## 요구사항

### 기본
컨트롤러 레이어 구현
- [X] DiscodeitApplication의 테스트 로직은 삭제하세요.
- [X] 지금까지 구현한 서비스 로직을 활용해 웹 API를 구현하세요. 이때 @RequestMapping만 사용해 구현해보세요.
- [X] 웹 API의 예외를 전역으로 처리하세요.

### 웹 API 요구사항

사용자 관리
  - [X] 사용자를 등록할 수 있다.
  - [X] 사용자 정보를 수정할 수 있다.
  - [X] 사용자를 삭제할 수 있다.
  - [X] 모든 사용자를 조회할 수 있다.
  - [X] 사용자의 온라인 상태를 업데이트할 수 있다.

권한 관리
  - [X] 사용자는 로그인할 수 있다.

채널 관리
  - [X] 공개 채널을 생성할 수 있다.
  - [X] 비공개 채널을 생성할 수 있다.
  - [X] 공개 채널의 정보를 수정할 수 있다.
  - [X] 채널을 삭제할 수 있다.
  - [X] 특정 사용자가 볼 수 있는 모든 채널 목록을 조회할 수 있다.

메시지 관리
  - [X] 메시지를 보낼 수 있다.
  - [X] 메시지를 수정할 수 있다.
  - [X] 메시지를 삭제할 수 있다.
  - [X] 특정 채널의 메시지 목록을 조회할 수 있다.

메시지 수신 정보 관리
  - [X] 특정 채널의 메시지 수신 정보를 생성할 수 있다.
  - [X] 특정 채널의 메시지 수신 정보를 수정할 수 있다.
  - [X] 특정 사용자의 메시지 수신 정보를 조회할 수 있다.

바이너리 파일 다운로드
  - [X] 바이너리 파일을 1개 또는 여러 개 조회할 수 있다.


### API 테스트
- [X] Postman을 활용해 컨트롤러를 테스트 하세요.
- [X] Postman API 테스트 결과를 다음과 같이 export하여 PR에 첨부해주세요.
[part1-sprint4.postman_collection.json](https://github.com/user-attachments/files/19525264/part1-sprint4.postman_collection.json)
[New Environment.postman_environment.json](https://github.com/user-attachments/files/19525266/New.Environment.postman_environment.json)

### 심화
정적 리소스 서빙
- [X] 사용자 목록 조회, BinaryContent 파일 조회 API를 다음의 조건을 만족하도록 수정하세요.
  - [X] 사용자 목록 조회
    - url: /api/user/findAll
    - 요청
      - 파라미터, 바디 없음
    - 응답
      - ResponseEntity<List<UserDto>>
  - [X] BinaryContent 파일 조회
    - url: /api/binaryContent/find
    - 요청
      - 파라미터: binaryContentId
      - 바디 없음
    - 응답
      - ResponseEntity<BinaryContent>
- [X]  다음의 파일을 활용하여 사용자 목록을 보여주는 화면을 서빙해보세요.
- [X] 생성형 AI (Claude, ChatGPT 등)를 활용해서 위 이미지와 비슷한 화면을 생성 후 서빙해보세요.


## 주요 변경사항
- 지난 코드 리뷰 내용을 반영했습니다.
- 정적 리소스 서빙에 url을 /api/users/findAll로 하고 js 파일에서 요청할 때 url을 수정하여 사용했습니다.
- stream을 적재적소에 쓰려고 했는데 그게 잘 됐는지는 모르겠습니다,,

## 스크린샷
![스크린샷 2025-03-30 오후 6 45 03](https://github.com/user-attachments/assets/553f2b82-3e6e-40ee-bd5e-a22ec487a1fe)

## 멘토에게
- Part1 동안 감사했습니다!
