### PR TITLE
[김민식] sprint7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.5'
+    id 'org.springframework.boot' version '3.4.0'
     id 'io.spring.dependency-management' version '1.1.3'
 }
 
@@ -35,6 +35,10 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     // 유효성 검사를 위한 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // Spring Boot Actuator를 사용하기 위한 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // javax.annotation
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     // JPA 이용을 위한 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
+    // 유효성 검사를 위한 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sprint/mission/discodeit/common/code/ResultCode.java
+++ b/src/main/java/com/sprint/mission/discodeit/common/code/ResultCode.java
@@ -12,6 +12,7 @@ public enum ResultCode implements Code {
   INVALID_JSON(400, "JSON 형식이 잘못되었습니다."),
   READ_STATUS_ALREADY_EXISTS(400, "이미 읽음 상태가 존재합니다."),
   USER_STATUS_ALREADY_EXISTS(400, "이미 사용자 상태가 존재합니다."),
+  INVALID_CHANNEL_DATA(400, "채널명이 입력되지 않았습니다."),
 
   // 404 Not Found
   USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
@@ -23,6 +23,7 @@ public class AuthController {
   @PostMapping("/login")
   public ResponseEntity<UserResponse> login(@RequestBody UserLoginRequest loginRequest) {
     User user = authService.login(loginRequest);
-    return ResponseEntity.ok(userMapper.toResponse(user));
+    // 로그인 시 항상 온라인 상태로 처리
+    return ResponseEntity.ok(userMapper.toResponse(user, true));
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.service.AuthService;
 import com.sprint.mission.discodeit.util.LogUtils;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -26,7 +27,7 @@ public class AuthController {
 
 
   @PostMapping("/login")
-  public ResponseEntity<UserResponse> login(@RequestBody UserLoginRequest loginRequest) {
+  public ResponseEntity<UserResponse> login(@Valid @RequestBody UserLoginRequest loginRequest) {
     String traceId = MDC.get("traceId");
 
     // 시작 로그

--- a/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/AuthController.java
@@ -5,13 +5,17 @@ import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.service.AuthService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/auth")
@@ -20,10 +24,24 @@ public class AuthController {
   private final AuthService authService;
   private final UserMapper userMapper;
 
+
   @PostMapping("/login")
   public ResponseEntity<UserResponse> login(@RequestBody UserLoginRequest loginRequest) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[LOGIN] status=START, username={}, traceId={}",
+        log.isDebugEnabled() ? loginRequest.username() : LogUtils.mask(loginRequest.username()),
+        traceId);
+
     User user = authService.login(loginRequest);
     // 로그인 시 항상 온라인 상태로 처리
-    return ResponseEntity.ok(userMapper.toResponse(user, true));
+    UserResponse response = userMapper.toResponse(user, true);
+
+    // 성공 로그
+    log.info("[LOGIN] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(user.getId()), traceId);
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/controller/BinaryContentController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/BinaryContentController.java
@@ -5,7 +5,10 @@ import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.mapper.BinaryContentMapper;
 import com.sprint.mission.discodeit.service.BinaryContentService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import com.sprint.mission.discodeit.util.LogUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/binaryContents")
 @RequiredArgsConstructor
@@ -28,30 +32,62 @@ public class BinaryContentController {
   // 단일 파일 조회
   @GetMapping("/{binaryContentId}")
   public ResponseEntity<BinaryContentResponse> findFile(@PathVariable UUID binaryContentId) {
-    BinaryContent content = binaryContentService.findById(binaryContentId);
+    String traceId = MDC.get("traceId");
 
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(binaryContentMapper.toResponse(content));
+    // 시작 로그
+    log.info("[FIND] status=START, contentId={}, traceId={}",
+        log.isDebugEnabled() ? binaryContentId : LogUtils.maskUUID(binaryContentId), traceId);
+
+    BinaryContent content = binaryContentService.findById(binaryContentId);
+    BinaryContentResponse response = binaryContentMapper.toResponse(content);
+
+    // 성공 로그
+    log.info("[FIND] status=SUCCESS, contentId={}, traceId={}",
+        LogUtils.maskUUID(binaryContentId), traceId);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 
   // 여러 파일 조회
   @GetMapping
   public ResponseEntity<List<BinaryContentResponse>> findFiles(
       @RequestParam("binaryContentIds") List<UUID> binaryContentIds) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, contentIds={}, traceId={}",
+        log.isDebugEnabled() ? binaryContentIds : LogUtils.maskUUIDList(binaryContentIds), traceId);
+
     List<BinaryContent> binaryContents = binaryContentService.findAllByIdIn(binaryContentIds);
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(binaryContents.stream().map(binaryContentMapper::toResponse).toList());
+    List<BinaryContentResponse> responses = binaryContents.stream()
+        .map(binaryContentMapper::toResponse)
+        .toList();
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, contentCount={}, traceId={}",
+        responses.size(), traceId);
+
+    return ResponseEntity.status(HttpStatus.OK).body(responses);
   }
 
   // 파일 다운로드
   @GetMapping("{binaryContentId}/download")
   public ResponseEntity<?> downloadFile(@PathVariable UUID binaryContentId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DOWNLOAD] status=START, contentId={}, traceId={}",
+        log.isDebugEnabled() ? binaryContentId : LogUtils.maskUUID(binaryContentId), traceId);
+
     BinaryContent content = binaryContentService.findById(binaryContentId);
     BinaryContentResponse response = binaryContentMapper.toResponse(content);
-    return binaryContentStorage.download(response);
+    ResponseEntity<?> downloadResponse = binaryContentStorage.download(response);
 
+    // 성공 로그
+    log.info("[DOWNLOAD] status=SUCCESS, contentId={}, traceId={}",
+        LogUtils.maskUUID(binaryContentId), traceId);
+
+    return downloadResponse;
   }
 }
 

--- a/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
@@ -6,7 +6,6 @@ import com.sprint.mission.discodeit.dto2.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.dto2.response.ChannelResponse;
 import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.mapper.ChannelMapper;
 import com.sprint.mission.discodeit.service.ChannelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +22,16 @@ import java.util.UUID;
 public class ChannelController {
 
   private final ChannelService channelService;
-  private final ChannelMapper channelMapper;
 
   // 공개 채널 생성
   @PostMapping("/public")
   public ResponseEntity<ChannelResponse> createPublicChannel(
       @Valid @RequestBody PublicChannelCreateRequest request) {
+    // 채널 생성
     Channel createdChannel = channelService.createPublicChannel(request);
-    return ResponseEntity.status(HttpStatus.CREATED).body(channelMapper.toResponse(createdChannel));
+    // 생성된 채널의 Response 반환
+    ChannelResponse response = channelService.getChannelResponse(createdChannel);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   // 비공개 채널 생성
@@ -38,7 +39,8 @@ public class ChannelController {
   public ResponseEntity<ChannelResponse> createPrivateChannel(
       @Valid @RequestBody PrivateChannelCreateRequest request) {
     Channel createdChannel = channelService.createPrivateChannel(request);
-    return ResponseEntity.status(HttpStatus.CREATED).body(channelMapper.toResponse(createdChannel));
+    ChannelResponse response = channelService.getChannelResponse(createdChannel);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   // 공개 채널 정보 수정
@@ -47,7 +49,8 @@ public class ChannelController {
       @PathVariable UUID channelId,
       @Valid @RequestBody PublicChannelUpdateRequest request) {
     Channel updatedChannel = channelService.update(channelId, request);
-    return ResponseEntity.ok(channelMapper.toResponse(updatedChannel));
+    ChannelResponse response = channelService.getChannelResponse(updatedChannel);
+    return ResponseEntity.ok(response);
   }
 
   // 채널 삭제
@@ -62,8 +65,9 @@ public class ChannelController {
   public ResponseEntity<List<ChannelResponse>> getChannelsForUser(
       @RequestParam UUID userId) {
     List<Channel> channels = channelService.findAllByUserId(userId);
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(channels.stream().map(channelMapper::toResponse).toList());
+    List<ChannelResponse> responses = channels.stream()
+        .map(channelService::getChannelResponse)
+        .toList();
+    return ResponseEntity.ok(responses);
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
@@ -7,8 +7,11 @@ import com.sprint.mission.discodeit.dto2.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.dto2.response.ChannelResponse;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/channels")
 @RequiredArgsConstructor
@@ -27,10 +31,20 @@ public class ChannelController {
   @PostMapping("/public")
   public ResponseEntity<ChannelResponse> createPublicChannel(
       @Valid @RequestBody PublicChannelCreateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[CREATE] status=START, channelName={}, traceId={}",
+        log.isDebugEnabled() ? request.name() : LogUtils.mask(request.name()), traceId);
+
     // 채널 생성
     Channel createdChannel = channelService.createPublicChannel(request);
     // 생성된 채널의 Response 반환
     ChannelResponse response = channelService.getChannelResponse(createdChannel);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(createdChannel.getId()), traceId);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -38,8 +52,20 @@ public class ChannelController {
   @PostMapping("/private")
   public ResponseEntity<ChannelResponse> createPrivateChannel(
       @Valid @RequestBody PrivateChannelCreateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[CREATE] status=START, participantIds={}, traceId={}",
+        log.isDebugEnabled() ? request.userIds() : LogUtils.maskUUIDList(request.userIds()),
+        traceId);
+
     Channel createdChannel = channelService.createPrivateChannel(request);
     ChannelResponse response = channelService.getChannelResponse(createdChannel);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(createdChannel.getId()), traceId);
+
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -48,15 +74,35 @@ public class ChannelController {
   public ResponseEntity<ChannelResponse> updatePublicChannel(
       @PathVariable UUID channelId,
       @Valid @RequestBody PublicChannelUpdateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[UPDATE] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId), traceId);
+
     Channel updatedChannel = channelService.update(channelId, request);
     ChannelResponse response = channelService.getChannelResponse(updatedChannel);
+
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(channelId), traceId);
     return ResponseEntity.ok(response);
   }
 
   // 채널 삭제
   @DeleteMapping("/{channelId}")
   public ResponseEntity<Void> deleteChannel(@PathVariable UUID channelId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId), traceId);
+
     channelService.delete(channelId);
+
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(channelId), traceId);
     return ResponseEntity.noContent().build();
   }
 
@@ -64,10 +110,20 @@ public class ChannelController {
   @GetMapping
   public ResponseEntity<List<ChannelResponse>> getChannelsForUser(
       @RequestParam UUID userId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, userId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId), traceId);
+
     List<Channel> channels = channelService.findAllByUserId(userId);
     List<ChannelResponse> responses = channels.stream()
         .map(channelService::getChannelResponse)
         .toList();
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, userId={}, channelCount={}, traceId={}",
+        LogUtils.maskUUID(userId), responses.size(), traceId);
     return ResponseEntity.ok(responses);
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ChannelController.java
@@ -8,6 +8,7 @@ import com.sprint.mission.discodeit.dto2.response.ChannelResponse;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.mapper.ChannelMapper;
 import com.sprint.mission.discodeit.service.ChannelService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class ChannelController {
   // 공개 채널 생성
   @PostMapping("/public")
   public ResponseEntity<ChannelResponse> createPublicChannel(
-      @RequestBody PublicChannelCreateRequest request) {
+      @Valid @RequestBody PublicChannelCreateRequest request) {
     Channel createdChannel = channelService.createPublicChannel(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(channelMapper.toResponse(createdChannel));
   }
@@ -35,7 +36,7 @@ public class ChannelController {
   // 비공개 채널 생성
   @PostMapping("/private")
   public ResponseEntity<ChannelResponse> createPrivateChannel(
-      @RequestBody PrivateChannelCreateRequest request) {
+      @Valid @RequestBody PrivateChannelCreateRequest request) {
     Channel createdChannel = channelService.createPrivateChannel(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(channelMapper.toResponse(createdChannel));
   }
@@ -44,7 +45,7 @@ public class ChannelController {
   @PatchMapping("/{channelId}")
   public ResponseEntity<ChannelResponse> updatePublicChannel(
       @PathVariable UUID channelId,
-      @RequestBody PublicChannelUpdateRequest request) {
+      @Valid @RequestBody PublicChannelUpdateRequest request) {
     Channel updatedChannel = channelService.update(channelId, request);
     return ResponseEntity.ok(channelMapper.toResponse(updatedChannel));
   }

--- a/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
@@ -9,6 +9,7 @@ import com.sprint.mission.discodeit.mapper.MessageMapper;
 import com.sprint.mission.discodeit.mapper.PageResponseMapper;
 import com.sprint.mission.discodeit.service.MessageService;
 import com.sprint.mission.discodeit.util.LogUtils;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -38,7 +39,7 @@ public class MessageController {
   // 메시지 보내기
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<MessageResponse> sendMessage(
-      @RequestPart MessageCreateRequest messageCreateRequest,
+      @Valid @RequestPart MessageCreateRequest messageCreateRequest,
       @RequestPart(required = false) List<MultipartFile> attachments) {
     String traceId = MDC.get("traceId");
 
@@ -65,7 +66,7 @@ public class MessageController {
   @PatchMapping("/{messageId}")
   public ResponseEntity<MessageResponse> updateMessage(
       @PathVariable UUID messageId,
-      @RequestBody MessageUpdateRequest messageUpdateRequest) {
+      @Valid @RequestBody MessageUpdateRequest messageUpdateRequest) {
     String traceId = MDC.get("traceId");
 
     // 시작 로그

--- a/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
@@ -8,7 +8,10 @@ import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.mapper.MessageMapper;
 import com.sprint.mission.discodeit.mapper.PageResponseMapper;
 import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -23,6 +26,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/messages")
 @RequiredArgsConstructor
@@ -36,9 +40,25 @@ public class MessageController {
   public ResponseEntity<MessageResponse> sendMessage(
       @RequestPart MessageCreateRequest messageCreateRequest,
       @RequestPart(required = false) List<MultipartFile> attachments) {
+    String traceId = MDC.get("traceId");
 
+    // 시작 로그
+    log.info("[CREATE] status=START, authorId={}, channelId={}, traceId={}",
+        log.isDebugEnabled() ? messageCreateRequest.authorId()
+            : LogUtils.maskUUID(messageCreateRequest.authorId()),
+        log.isDebugEnabled() ? messageCreateRequest.channelId()
+            : LogUtils.maskUUID(messageCreateRequest.channelId()),
+        traceId);
+
+    // 메시지 생성
     Message message = messageService.create(messageCreateRequest, attachments);
-    return ResponseEntity.status(HttpStatus.CREATED).body(messageMapper.toResponse(message));
+    MessageResponse response = messageMapper.toResponse(message);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, messageId={}, traceId={}",
+        LogUtils.maskUUID(message.getId()), traceId);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   // 메시지 수정
@@ -46,15 +66,39 @@ public class MessageController {
   public ResponseEntity<MessageResponse> updateMessage(
       @PathVariable UUID messageId,
       @RequestBody MessageUpdateRequest messageUpdateRequest) {
+    String traceId = MDC.get("traceId");
 
+    // 시작 로그
+    log.info("[UPDATE] status=START, messageId={}, traceId={}",
+        log.isDebugEnabled() ? messageId : LogUtils.maskUUID(messageId), traceId);
+
+    // 메시지 수정
     Message updatedMessage = messageService.update(messageId, messageUpdateRequest);
-    return ResponseEntity.status(HttpStatus.CREATED).body(messageMapper.toResponse(updatedMessage));
+    MessageResponse response = messageMapper.toResponse(updatedMessage);
+
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, messageId={}, traceId={}",
+        LogUtils.maskUUID(updatedMessage.getId()), traceId);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 
   // 메시지 삭제
   @DeleteMapping("/{messageId}")
   public ResponseEntity<Void> deleteMessage(@PathVariable UUID messageId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, messageId={}, traceId={}",
+        log.isDebugEnabled() ? messageId : LogUtils.maskUUID(messageId), traceId);
+
+    // 메시지 삭제
     messageService.delete(messageId);
+
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, messageId={}, traceId={}",
+        LogUtils.maskUUID(messageId), traceId);
+
     return ResponseEntity.noContent().build();
   }
 
@@ -63,12 +107,21 @@ public class MessageController {
   public ResponseEntity<PageResponse<MessageResponse>> getMessagesByChannel(
       @RequestParam UUID channelId,
       @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId), traceId);
 
     Slice<Message> messages = messageService.findAllByChannelId(channelId, pageable);
 
     List<MessageResponse> messageResponses = messages.stream()
         .map(messageMapper::toResponse)
         .toList();
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, channelId={}, messageCount={}, traceId={}",
+        LogUtils.maskUUID(channelId), messageResponses.size(), traceId);
 
     return ResponseEntity.ok(PageResponseMapper.fromSlice(
         new SliceImpl<>(messageResponses, pageable, messages.hasNext())

--- a/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
@@ -5,6 +5,7 @@ import com.sprint.mission.discodeit.dto2.request.ReadStatusUpdateRequest;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.service.ReadStatusService;
 import com.sprint.mission.discodeit.util.LogUtils;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -26,7 +27,7 @@ public class ReadStatusController {
   // 1. 특정 채널의 메시지 수신 정보 생성
   @PostMapping
   public ResponseEntity<ReadStatus> createReceipts(
-      @RequestBody ReadStatusCreateRequest request) {
+      @Valid @RequestBody ReadStatusCreateRequest request) {
     String traceId = MDC.get("traceId");
     UUID userId = request.userId();
     UUID channelId = request.channelId();
@@ -50,7 +51,7 @@ public class ReadStatusController {
   @PatchMapping("/{readStatusId}")
   public ResponseEntity<ReadStatus> updateReceipts(
       @PathVariable UUID readStatusId,
-      @RequestBody ReadStatusUpdateRequest request) {
+      @Valid @RequestBody ReadStatusUpdateRequest request) {
     String traceId = MDC.get("traceId");
 
     // 시작 로그

--- a/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/ReadStatusController.java
@@ -1,11 +1,13 @@
 package com.sprint.mission.discodeit.controller;
 
-import com.sprint.mission.discodeit.dto2.response.ApiResponse;
 import com.sprint.mission.discodeit.dto2.request.ReadStatusCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.ReadStatusUpdateRequest;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.service.ReadStatusService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/readStatuses")
 @RequiredArgsConstructor
@@ -24,7 +27,22 @@ public class ReadStatusController {
   @PostMapping
   public ResponseEntity<ReadStatus> createReceipts(
       @RequestBody ReadStatusCreateRequest request) {
+    String traceId = MDC.get("traceId");
+    UUID userId = request.userId();
+    UUID channelId = request.channelId();
+
+    // 시작 로그
+    log.info("[CREATE] status=START, userId={}, channelId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId),
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId),
+        traceId);
+
     ReadStatus readStatus = readStatusService.create(request);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, readStatusId={}, traceId={}",
+        LogUtils.maskUUID(readStatus.getId()), traceId);
+
     return ResponseEntity.status(HttpStatus.CREATED).body(readStatus);
   }
 
@@ -33,14 +51,36 @@ public class ReadStatusController {
   public ResponseEntity<ReadStatus> updateReceipts(
       @PathVariable UUID readStatusId,
       @RequestBody ReadStatusUpdateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[UPDATE] status=START, readStatusId={}, traceId={}",
+        log.isDebugEnabled() ? readStatusId : LogUtils.maskUUID(readStatusId), traceId);
+
     ReadStatus updated = readStatusService.update(readStatusId, request);
+
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, readStatusId={}, traceId={}",
+        LogUtils.maskUUID(updated.getId()), traceId);
+
     return ResponseEntity.ok(updated);
   }
 
   // 3. 특정 사용자의 메시지 수신 정보 조회
   @GetMapping
   public ResponseEntity<List<ReadStatus>> getAllByUserId(@RequestParam UUID userId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, userId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId), traceId);
+
     List<ReadStatus> readStatuses = readStatusService.findAllByUserId(userId);
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, userId={}, readStatusCount={}, traceId={}",
+        LogUtils.maskUUID(userId), readStatuses.size(), traceId);
+
     return ResponseEntity.ok(readStatuses);
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
@@ -11,10 +11,7 @@ import com.sprint.mission.discodeit.dto2.response.UserStatusResponse;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.invalid.InvalidJsonFormatException;
-import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.mapper.UserStatusMapper;
-import com.sprint.mission.discodeit.service.BinaryContentService;
 import com.sprint.mission.discodeit.service.UserService;
 import com.sprint.mission.discodeit.service.UserStatusService;
 import com.sprint.mission.discodeit.service.basic.BasicBinaryContentService;
@@ -36,7 +33,6 @@ public class UserController {
 
   private final UserService userService;
   private final UserStatusService userStatusService;
-  private final UserMapper userMapper;
   private final UserStatusMapper userStatusMapper;
   private final BasicBinaryContentService binaryContentService;
 
@@ -58,9 +54,10 @@ public class UserController {
         binaryContentService.resolveProfileRequest(profile);
 
     User createdUser = userService.create(userCreateRequest, profileRequest);
+    UserResponse response = userService.getUserResponse(createdUser);
     return ResponseEntity
         .status(HttpStatus.CREATED)
-        .body(userMapper.toResponse(createdUser));
+        .body(response);
   }
 
   // User 수정
@@ -72,9 +69,10 @@ public class UserController {
     Optional<BinaryContentCreateRequest> profileRequest =
         binaryContentService.resolveProfileRequest(profile);
     User updatedUser = userService.update(userId, userUpdateRequest, profileRequest);
+    UserResponse response = userService.getUserResponse(updatedUser);
     return ResponseEntity
         .status(HttpStatus.OK)
-        .body(userMapper.toResponse(updatedUser));
+        .body(response);
   }
 
   // User 삭제
@@ -90,7 +88,10 @@ public class UserController {
   @GetMapping
   public ResponseEntity<List<UserResponse>> getUsers() {
     List<User> users = userService.findAll();
-    return ResponseEntity.ok(users.stream().map(userMapper::toResponse).toList());
+    List<UserResponse> responses = users.stream()
+        .map(userService::getUserResponse)
+        .toList();
+    return ResponseEntity.ok(responses);
   }
 
   // 온라인 상태 갱신

--- a/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/UserController.java
@@ -16,6 +16,7 @@ import com.sprint.mission.discodeit.service.UserService;
 import com.sprint.mission.discodeit.service.UserStatusService;
 import com.sprint.mission.discodeit.service.basic.BasicBinaryContentService;
 import com.sprint.mission.discodeit.util.LogUtils;
+import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class UserController {
   // User 등록
   @PostMapping(consumes = "multipart/form-data")
   public ResponseEntity<UserResponse> createUser(
-      @RequestPart("userCreateRequest") String userCreateRequestJson,
+      @Valid @RequestPart("userCreateRequest") String userCreateRequestJson,
       @RequestPart(value = "profile", required = false) MultipartFile profile) {
     String traceId = MDC.get("traceId");
 
@@ -80,7 +81,7 @@ public class UserController {
   @PatchMapping(value = "/{userId}", consumes = "multipart/form-data")
   public ResponseEntity<UserResponse> updateUser(
       @PathVariable UUID userId,
-      @RequestPart("userUpdateRequest") UserUpdateRequest userUpdateRequest,
+      @Valid @RequestPart("userUpdateRequest") UserUpdateRequest userUpdateRequest,
       @RequestPart(value = "profile", required = false) MultipartFile profile) {
     String traceId = MDC.get("traceId");
 
@@ -145,7 +146,7 @@ public class UserController {
   // 온라인 상태 갱신
   @PatchMapping("/{userId}/userStatus")
   public ResponseEntity<UserStatusResponse> updateUserStatus(@PathVariable UUID userId,
-      @RequestBody UserStatusUpdateRequest request) {
+      @Valid @RequestBody UserStatusUpdateRequest request) {
     String traceId = MDC.get("traceId");
 
     // 시작 로그

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/BinaryContentCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/BinaryContentCreateRequest.java
@@ -1,8 +1,20 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record BinaryContentCreateRequest(
+    @NotBlank(message = "File name is required")
+    @Size(max = 255, message = "Please enter a file name of 255 characters or less.")
     String fileName,
+
+    @NotBlank(message = "Content type is required.")
+    @Size(max = 100, message = "Please enter content type within 100 characters.")
     String contentType,
+
+    @NotNull(message = "File byte data is a required field.")
+    @Size(min = 1, message = "The file cannot contain empty data.")
     byte[] bytes
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/MessageCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/MessageCreateRequest.java
@@ -1,11 +1,17 @@
 package com.sprint.mission.discodeit.dto2.request;
 
-import java.util.List;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record MessageCreateRequest(
+    @NotBlank(message = "Message content is required.")
     String content,
+
+    @NotNull(message = "Author ID is required.")
     UUID authorId,
+
+    @NotNull(message = "Channel ID is required.")
     UUID channelId
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/MessageUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/MessageUpdateRequest.java
@@ -1,9 +1,9 @@
 package com.sprint.mission.discodeit.dto2.request;
 
-import java.util.UUID;
+import jakarta.validation.constraints.NotBlank;
 
 public record MessageUpdateRequest(
-//   UUID id,
+    @NotBlank(message = "New message content is required.")
     String newContent
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/PrivateChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/PrivateChannelCreateRequest.java
@@ -1,11 +1,13 @@
 package com.sprint.mission.discodeit.dto2.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import java.util.UUID;
 
 public record PrivateChannelCreateRequest(
     @JsonProperty("participantIds")
+    @NotEmpty(message = "Participant IDs must not be empty")
     List<UUID> userIds
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/PrivateChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/PrivateChannelCreateRequest.java
@@ -2,13 +2,14 @@ package com.sprint.mission.discodeit.dto2.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
 public record PrivateChannelCreateRequest(
     @JsonProperty("participantIds")
     @NotEmpty(message = "Participant IDs must not be empty")
-    List<UUID> userIds
+    List<@NotNull(message = "Each participant ID is required.") UUID> userIds
 ) {
 
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelCreateRequest.java
@@ -1,6 +1,14 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.lang.Nullable;
+
 public record PublicChannelCreateRequest(
-        String name,
-        String description
-) {}
+    @NotBlank(message = "Channel name must not be blank")
+    String name,
+
+    @Nullable
+    String description
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelCreateRequest.java
@@ -1,13 +1,16 @@
 package com.sprint.mission.discodeit.dto2.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.lang.Nullable;
 
 public record PublicChannelCreateRequest(
-    @NotBlank(message = "Channel name must not be blank")
+    @NotBlank(message = "Channel name must not be blank.")
+    @Size(max = 100, message = "Channel name must be at most 100 characters.")
     String name,
 
     @Nullable
+    @Size(max = 500, message = "Channel description must be at most 500 characters.")
     String description
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelUpdateRequest.java
@@ -1,13 +1,16 @@
 package com.sprint.mission.discodeit.dto2.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.lang.Nullable;
 
 public record PublicChannelUpdateRequest(
-    @NotBlank(message = "New channel name must not be blank")
+    @NotBlank(message = "New channel name must not be blank.")
+    @Size(max = 100, message = "New channel name must be at most 100 characters.")
     String newName,
 
     @Nullable
+    @Size(max = 500, message = "New channel description must be at most 500 characters.")
     String newDescription
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/PublicChannelUpdateRequest.java
@@ -1,7 +1,13 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.lang.Nullable;
+
 public record PublicChannelUpdateRequest(
+    @NotBlank(message = "New channel name must not be blank")
     String newName,
+
+    @Nullable
     String newDescription
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/ReadStatusCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/ReadStatusCreateRequest.java
@@ -1,10 +1,18 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.UUID;
 
 public record ReadStatusCreateRequest(
-        UUID userId,
-        UUID channelId,
-        Instant lastReadAt
-) {}
+    @NotNull(message = "User ID is required.")
+    UUID userId,
+
+    @NotNull(message = "Channel ID is required.")
+    UUID channelId,
+
+    @NotNull(message = "Last read timestamp is required.")
+    Instant lastReadAt
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/ReadStatusUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/ReadStatusUpdateRequest.java
@@ -1,9 +1,10 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.util.UUID;
 
 public record ReadStatusUpdateRequest(
+    @NotNull(message = "New last read timestamp is required.")
     Instant newLastReadAt
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/UserCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/UserCreateRequest.java
@@ -2,14 +2,20 @@ package com.sprint.mission.discodeit.dto2.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record UserCreateRequest(
-//    @NotBlank(message = "아이디는 필수입니다.")
+    @NotBlank(message = "Username is required.")
+    @Size(max = 50, message = "Username must be at most 50 characters.")
     String username,
-//    @NotBlank(message = "이메일은 필수입니다.")
-//    @Email(message = "이메일 형식이 올바르지 않습니다.")
+
+    @NotBlank(message = "Email is required.")
+    @Email(message = "Invalid email format.")
+    @Size(max = 100, message = "Email must be at most 100 characters.")
     String email,
-//    @NotBlank(message = "비밀번호는 필수입니다.")
+
+    @NotBlank(message = "Password is required.")
+    @Size(min = 8, max = 60, message = "Password must be between 8 and 60 characters.")
     String password
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/UserLoginRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/UserLoginRequest.java
@@ -1,6 +1,16 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record UserLoginRequest(
-        String username,
-        String password
-) {}
+    @NotBlank(message = "Username is required.")
+    @Size(max = 50, message = "Username must be at most 50 characters.")
+    String username,
+
+    @NotBlank(message = "Password is required.")
+    @Size(min = 8, max = 60, message = "Password must be between 8 and 60 characters.")
+    String password
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/UserStatusCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/UserStatusCreateRequest.java
@@ -1,9 +1,15 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.UUID;
 
 public record UserStatusCreateRequest(
-        UUID userId,
-        Instant lastAccessedAt
-) {}
+    @NotNull(message = "User ID is required.")
+    UUID userId,
+
+    @NotNull(message = "Last accessed timestamp is required.")
+    Instant lastAccessedAt
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/UserStatusUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/UserStatusUpdateRequest.java
@@ -1,9 +1,10 @@
 package com.sprint.mission.discodeit.dto2.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.util.UUID;
 
 public record UserStatusUpdateRequest(
+    @NotNull(message = "New last active timestamp is required.")
     Instant newLastActiveAt
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/dto2/request/UserUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto2/request/UserUpdateRequest.java
@@ -1,10 +1,17 @@
 package com.sprint.mission.discodeit.dto2.request;
 
-import java.util.UUID;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
 
 public record UserUpdateRequest(
+    @Size(max = 50, message = "New username must be at most 50 characters.")
     String newUsername,
+
+    @Email(message = "Invalid email format.")
+    @Size(max = 100, message = "New email must be at most 100 characters.")
     String newEmail,
+
+    @Size(min = 8, max = 60, message = "New password must be between 8 and 60 characters.")
     String newPassword// 선택적 필드
 ) {
 

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -2,13 +2,10 @@ package com.sprint.mission.discodeit.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import java.io.Serializable;
-import java.time.Instant;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import java.util.UUID;
 import lombok.NoArgsConstructor;
 
 @Getter
@@ -26,9 +23,7 @@ public class BinaryContent extends BaseEntity {
   @Column(name = "content_type", length = 100, nullable = false)
   private String contentType; // 파일의 MIME 타입 (예: image/png)
 
-//  @Column(name = "bytes", nullable = false, columnDefinition = "BYTEA")
-//  private byte[] bytes; // 실제 데이터 (효율적인 저장을 위해 변경)
-
+  @Builder
   public BinaryContent(String fileName, Long size, String contentType) {
     this.fileName = fileName;
     this.size = size;

--- a/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -6,9 +6,9 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
-import java.time.Instant;
 import lombok.NoArgsConstructor;
 
 @Getter
@@ -26,6 +26,7 @@ public class Channel extends BaseUpdatableEntity {
   @Column(length = 500)
   private String description;
 
+  @Builder
   public Channel(ChannelType type, String name, String description) {
     this.type = type;
     this.name = name;

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -9,6 +9,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -44,6 +45,7 @@ public class Message extends BaseUpdatableEntity {
   )
   private List<BinaryContent> attachments = new ArrayList<>();
 
+  @Builder
   public Message(String content, Channel channel, User author, List<BinaryContent> attachments) {
     this.content = content;
     this.channel = channel;

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -9,10 +9,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.Instant;
-import java.util.UUID;
 import lombok.NoArgsConstructor;
 
 @Getter
@@ -38,6 +38,7 @@ public class ReadStatus extends BaseUpdatableEntity {
   @Column(name = "last_read_at", nullable = false)
   private Instant lastReadAt;
 
+  @Builder
   public ReadStatus(User user, Channel channel, Instant lastReadAt) {
     this.user = user;
     this.channel = channel;

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "read_statuses", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"userId", "channelId"})
+    @UniqueConstraint(columnNames = {"channelId", "userId"})
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // 사용자가 채널 별 마지막으로 메시지를 읽은 시간을 표현하는 도메인 모델

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 import jakarta.persistence.Entity;
@@ -38,6 +39,7 @@ public class User extends BaseUpdatableEntity {
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private UserStatus status;
 
+  @Builder
   public User(String username, String email, String password, BinaryContent profile) {
     this.username = username;
     this.email = email;

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,5 +54,10 @@ public class User extends BaseUpdatableEntity {
     this.email = email;
     this.password = password;
     this.profile = profile;
+  }
+
+  // 마지막 활동 시간 반환 메서드
+  public Instant getLastActiveAt() {
+    return status != null ? status.getLastActiveAt() : null;
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -7,11 +7,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.util.UUID;
 
 @Getter
 @Entity
@@ -28,6 +28,7 @@ public class UserStatus extends BaseUpdatableEntity {
   @Column(name = "last_active_at", nullable = false)
   private Instant lastActiveAt;
 
+  @Builder
   public UserStatus(User user, Instant lastActiveAt) {
     this.user = user;
     this.lastActiveAt = lastActiveAt;

--- a/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -42,4 +42,9 @@ public class UserStatus extends BaseUpdatableEntity {
   public void updateLastAccessedAt(Instant accessedAt) {
     this.lastActiveAt = accessedAt;
   }
+
+  // 온라인으로 상태 변환
+  public void setOnline() {
+    this.lastActiveAt = Instant.now();
+  }
 }

--- a/src/main/java/com/sprint/mission/discodeit/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/mission/discodeit/exceptionhandler/GlobalExceptionHandler.java
@@ -2,26 +2,16 @@ package com.sprint.mission.discodeit.exceptionhandler;
 
 import com.sprint.mission.discodeit.common.code.ResultCode;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.notfound.BinaryContentNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.ChannelNotFoundException;
-import com.sprint.mission.discodeit.exception.duplicate.DuplicateEmailException;
-import com.sprint.mission.discodeit.exception.duplicate.DuplicateReadStatusException;
-import com.sprint.mission.discodeit.exception.duplicate.DuplicateUsernameException;
 import com.sprint.mission.discodeit.dto2.response.ErrorResponse;
-import com.sprint.mission.discodeit.exception.FileProcessingException;
-import com.sprint.mission.discodeit.exception.invalid.InvalidChannelTypeException;
-import com.sprint.mission.discodeit.exception.invalid.InvalidJsonFormatException;
-import com.sprint.mission.discodeit.exception.invalid.InvalidPasswordException;
-import com.sprint.mission.discodeit.exception.notfound.MessageNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.ReadStatusNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserStatusNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -29,6 +19,12 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleRestException(RestException e,
       HttpServletRequest request) {
     ResultCode resultCode = e.getResultCode();
+//    String traceId = request.getHeader("traceId");
+    String traceId = MDC.get("traceId");
+
+    // 예외 로그 출력 (개인정보 제외)
+    log.error("Handled RestException: code={}, message={}, traceId={}",
+        resultCode.getCode(), resultCode.getMessage(), traceId, e);
 
     ErrorResponse errorResponse = new ErrorResponse(
         HttpStatus.valueOf(resultCode.getCode()),
@@ -37,5 +33,23 @@ public class GlobalExceptionHandler {
     );
 
     return ResponseEntity.status(resultCode.getCode()).body(errorResponse);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGenericException(Exception e,
+      HttpServletRequest request) {
+//    String traceId = request.getHeader("traceId");
+    String traceId = MDC.get("traceId");
+
+    // 예외 로그 출력 (StackTrace 포함)
+    log.error("Unhandled Exception: traceId={}, error={}", traceId, e.getMessage(), e);
+
+    ErrorResponse errorResponse = new ErrorResponse(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "An unexpected error occurred",
+        request.getRequestURI()
+    );
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/filter/TraceIdFilter.java
+++ b/src/main/java/com/sprint/mission/discodeit/filter/TraceIdFilter.java
@@ -1,0 +1,27 @@
+package com.sprint.mission.discodeit.filter;
+
+import jakarta.servlet.*;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class TraceIdFilter implements Filter {
+
+  private static final String TRACE_ID = "traceId";
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    try {
+      // Trace ID 생성
+      String traceId = UUID.randomUUID().toString().substring(0, 8);
+      MDC.put(TRACE_ID, traceId);
+      chain.doFilter(request, response);
+    } finally {
+      // 요청 처리 완료 후 Trace ID 제거
+      MDC.remove(TRACE_ID);
+    }
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/mapper/ChannelMapper.java
+++ b/src/main/java/com/sprint/mission/discodeit/mapper/ChannelMapper.java
@@ -3,11 +3,6 @@ package com.sprint.mission.discodeit.mapper;
 import com.sprint.mission.discodeit.dto2.response.ChannelResponse;
 import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.entity.ChannelType;
-import com.sprint.mission.discodeit.entity.Message;
-import com.sprint.mission.discodeit.repository.MessageRepository;
-import com.sprint.mission.discodeit.repository.ReadStatusRepository;
-import com.sprint.mission.discodeit.repository.UserRepository;
 import java.time.Instant;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
@@ -17,28 +12,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ChannelMapper {
 
-  private final MessageRepository messageRepository;
-  private final ReadStatusRepository readStatusRepository;
-  private final UserRepository userRepository;
-  private final UserMapper userMapper;
-
-  public ChannelResponse toResponse(Channel channel) {
-    // 가장 최근 메시지 시간 계산
-    Instant lastMessageAt = messageRepository.findAll().stream()
-        .filter(msg -> msg.getChannel().getId().equals(channel.getId()))
-        .map(Message::getCreatedAt)
-        .max(Comparator.naturalOrder())
-        .orElse(null);
-    // 참가자 목록 가져오기 (PRIVATE일 경우만)
-    List<UserResponse> participants = channel.getType() == ChannelType.PRIVATE
-        ? readStatusRepository.findUsersByChannelId(channel.getId()).stream()
-        .map(userRepository::findById)
-        .flatMap(Optional::stream)                         // Optional<User> → User
-        .map(userMapper::toResponse)                       // User → UserResponse
-        .toList()
-        : List.of();
-
-    // ChannelResponse 구성
+  public ChannelResponse toResponse(Channel channel, Instant lastMessageAt,
+      List<UserResponse> participants) {
     return new ChannelResponse(
         channel.getId(),
         channel.getType(),

--- a/src/main/java/com/sprint/mission/discodeit/mapper/MessageMapper.java
+++ b/src/main/java/com/sprint/mission/discodeit/mapper/MessageMapper.java
@@ -20,7 +20,8 @@ public class MessageMapper {
   public MessageResponse toResponse(Message message) {
     // 작성자 정보 구성
     User user = message.getAuthor();
-    UserResponse author = userMapper.toResponse(user);
+    //
+    UserResponse author = userMapper.toResponse(user, false);
 
     // 첨부 파일 변환
     List<BinaryContentResponse> attachments = message.getAttachments().stream()

--- a/src/main/java/com/sprint/mission/discodeit/mapper/UserMapper.java
+++ b/src/main/java/com/sprint/mission/discodeit/mapper/UserMapper.java
@@ -1,11 +1,8 @@
 package com.sprint.mission.discodeit.mapper;
 
-import com.sprint.mission.discodeit.common.CodeitConstants;
 import com.sprint.mission.discodeit.dto2.response.BinaryContentResponse;
 import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.entity.User;
-import com.sprint.mission.discodeit.repository.UserStatusRepository;
-import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,19 +10,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserMapper {
 
-  private final UserStatusRepository userStatusRepository;
   private final BinaryContentMapper binaryContentMapper;
 
-  public UserResponse toResponse(User user) {
-    // profile은 nullable
-    BinaryContentResponse profile = null;
-
-    if (user.getProfile() != null) {
-      profile = binaryContentMapper.toResponse(user.getProfile());
-    }
-
-    boolean isOnline = userStatusRepository.isUserOnline(user.getId(), Instant.now()
-        .minusSeconds(CodeitConstants.ONLINE_THRESHOLD_SECONDS));
+  public UserResponse toResponse(User user, boolean isOnline) {
+    BinaryContentResponse profile = user.getProfile() != null
+        ? binaryContentMapper.toResponse(user.getProfile())
+        : null;
 
     return new UserResponse(
         user.getId(),

--- a/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
@@ -6,10 +6,19 @@ import com.sprint.mission.discodeit.entity.BinaryContent;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface BinaryContentRepository extends JpaRepository<BinaryContent, UUID> {
 
   List<BinaryContent> findAllByIdIn(List<UUID> ids);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM BinaryContent b WHERE b.id IN :ids")
+  void deleteInBatch(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -3,6 +3,7 @@ package com.sprint.mission.discodeit.repository;
 import com.sprint.mission.discodeit.entity.Message;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -16,6 +17,8 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
 
   Slice<Message> findByChannelIdOrderByCreatedAtDesc(UUID channelId,
       Pageable pageable); // Slice와 JPA를 통해 자동으로 LIMIT, OFFSET, ORDER BY 등을 포함한 쿼리 생성
+
+  Optional<Message> findFirstByChannelIdOrderByCreatedAtDesc(UUID channelId); // 가장 최근 메시지 반환
 
 }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -23,4 +23,6 @@ public interface ChannelService {
   Channel update(UUID channelId, PublicChannelUpdateRequest request);
 
   void delete(UUID id);
+
+  ChannelResponse getChannelResponse(Channel channel);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -4,6 +4,7 @@ import com.sprint.mission.discodeit.dto2.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.UserCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.UserUpdateRequest;
 
+import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.entity.User;
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +24,6 @@ public interface UserService {
       Optional<BinaryContentCreateRequest> profileCreateRequest);  // User 정보 수정 (선택적 프로필 이미지 변경)
 
   void delete(UUID id);  // User 삭제 (BinaryContent, UserStatus 같이 삭제)
+
+  UserResponse getUserResponse(User user);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
@@ -8,11 +8,15 @@ import com.sprint.mission.discodeit.exception.RestException;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.AuthService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicAuthService implements AuthService {
@@ -23,23 +27,41 @@ public class BasicAuthService implements AuthService {
   @Override
   @Transactional(readOnly = true)
   public User login(UserLoginRequest loginRequest) {
+    String traceId = MDC.get("traceId");
     String username = loginRequest.username();
     String password = loginRequest.password();
 
+    // 시작 로그
+    log.info("[LOGIN] status=START, username={}, traceId={}",
+        log.isDebugEnabled() ? username : LogUtils.mask(username), traceId);
+
     User user = userRepository.findByUsername(username)
-        .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[LOGIN] User not found: username={}, traceId={}",
+              LogUtils.mask(username), traceId);
+          return new RestException(ResultCode.USER_NOT_FOUND);
+        });
 
     if (!user.getPassword().equals(password)) {
+      log.warn("[LOGIN] Invalid password for user: username={}, traceId={}",
+          LogUtils.mask(username), traceId);
       throw new RestException(ResultCode.INVALID_PASSWORD);
     }
 
     // 로그인 시 상태 갱신
     if (user.getStatus() == null) {
       userStatusRepository.save(new UserStatus(user, Instant.now()));
+      log.info("[LOGIN] User status created: userId={}, traceId={}",
+          LogUtils.maskUUID(user.getId()), traceId);
     } else {
       user.getStatus().setOnline();
+      log.info("[LOGIN] User set to online: userId={}, traceId={}",
+          LogUtils.maskUUID(user.getId()), traceId);
     }
 
+    // 성공 로그
+    log.info("[LOGIN] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(user.getId()), traceId);
     return user;
   }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
@@ -2,16 +2,14 @@ package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.common.code.ResultCode;
 import com.sprint.mission.discodeit.dto2.request.UserLoginRequest;
-import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.invalid.InvalidPasswordException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
-import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.AuthService;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BasicAuthService implements AuthService {
 
   private final UserRepository userRepository;
+  private final UserStatusRepository userStatusRepository;
 
   @Override
   @Transactional(readOnly = true)
@@ -34,6 +33,14 @@ public class BasicAuthService implements AuthService {
       throw new RestException(ResultCode.INVALID_PASSWORD);
     }
 
+    // 로그인 시 상태 갱신
+    if (user.getStatus() == null) {
+      userStatusRepository.save(new UserStatus(user, Instant.now()));
+    } else {
+      user.getStatus().setOnline();
+    }
+
     return user;
   }
+
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -7,9 +7,13 @@ import com.sprint.mission.discodeit.exception.RestException;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.service.BinaryContentService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import com.sprint.mission.discodeit.util.LogUtils;
 import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,6 +21,7 @@ import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicBinaryContentService implements BinaryContentService {
@@ -27,7 +32,13 @@ public class BasicBinaryContentService implements BinaryContentService {
   @Override
   @Transactional
   public BinaryContent create(BinaryContentCreateRequest request) {
+    String traceId = MDC.get("traceId");
     String fileName = request.fileName();
+
+    // 시작 로그
+    log.info("[CREATE] status=START, fileName={}, traceId={}",
+        log.isDebugEnabled() ? fileName : LogUtils.maskFileName(fileName), traceId);
+
     byte[] bytes = request.bytes();
     String contentType = request.contentType();
 
@@ -40,45 +51,116 @@ public class BasicBinaryContentService implements BinaryContentService {
     // 실제 데이터 저장
     try {
       binaryContentStorage.put(binaryContent.getId(), bytes);
+      log.info("[CREATE] BinaryContent created successfully: contentId={}, traceId={}",
+          binaryContent.getId(), traceId);
     } catch (Exception e) {
+      log.error("[ERROR] Failed to store BinaryContent: contentId={}, traceId={}",
+          binaryContent.getId(), traceId, e);
       throw new RestException(ResultCode.FILE_PROCESSING_ERROR);
     }
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, contentId={}, traceId={}",
+        binaryContent.getId(), traceId);
     return binaryContentRepository.save(binaryContent);
   }
 
   @Override
   @Transactional(readOnly = true)
   public BinaryContent findById(UUID id) {
-    return binaryContentRepository.findById(id)
-        .orElseThrow(() -> new RestException(ResultCode.BINARY_CONTENT_NOT_FOUND));
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND] status=START, contentId={}, traceId={}",
+        log.isDebugEnabled() ? id : LogUtils.maskUUID(id), traceId);
+
+    BinaryContent binaryContent = binaryContentRepository.findById(id)
+        .orElseThrow(() -> {
+          log.warn("[FIND] BinaryContent not found: contentId={}, traceId={}",
+              LogUtils.maskUUID(id), traceId);
+          return new RestException(ResultCode.BINARY_CONTENT_NOT_FOUND);
+        });
+
+    // 성공 로그
+    log.info("[FIND] status=SUCCESS, contentId={}, traceId={}",
+        LogUtils.maskUUID(id), traceId);
+    return binaryContent;
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<BinaryContent> findAllByIdIn(List<UUID> ids) {
-    return binaryContentRepository.findAllByIdIn(ids);
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, contentIds={}, traceId={}",
+        log.isDebugEnabled() ? ids : LogUtils.maskUUIDList(ids), traceId);
+
+    List<BinaryContent> contents = binaryContentRepository.findAllByIdIn(ids);
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, contentCount={}, traceId={}",
+        contents.size(), traceId);
+    return contents;
   }
 
   @Override
   @Transactional
   public void delete(UUID id) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, contentId={}, traceId={}",
+        log.isDebugEnabled() ? id : LogUtils.maskUUID(id), traceId);
+
     BinaryContent binaryContent = findById(id);
     binaryContentRepository.delete(binaryContent);
-    // 저장소에서도 삭제
-    binaryContentStorage.delete(id);
+
+    try {
+      // 저장소에서도 삭제
+      binaryContentStorage.delete(id);
+      log.info("[DELETE] BinaryContent deleted successfully: contentId={}, traceId={}",
+          id, traceId);
+    } catch (Exception e) {
+      log.error("[ERROR] Failed to delete BinaryContent from storage: contentId={}, traceId={}",
+          id, traceId, e);
+      throw new RestException(ResultCode.FILE_PROCESSING_ERROR);
+    }
+
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, contentId={}, traceId={}",
+        id, traceId);
   }
 
   public Optional<BinaryContentCreateRequest> resolveProfileRequest(MultipartFile profileFile) {
+    String traceId = MDC.get("traceId");
+
+    // 파일이 비어있는지 먼저 체크
     if (profileFile == null || profileFile.isEmpty()) {
+      log.info("[RESOLVE] status=SUCCESS, empty profile file, skipping: traceId={}", traceId);
       return Optional.empty();
     }
+
+    // 시작 로그
+    log.info("[RESOLVE] status=START, fileName={}, traceId={}",
+        log.isDebugEnabled() ? profileFile.getOriginalFilename()
+            : LogUtils.maskFileName(profileFile.getOriginalFilename()),
+        traceId);
+
     try {
-      return Optional.of(new BinaryContentCreateRequest(
+      BinaryContentCreateRequest request = new BinaryContentCreateRequest(
           profileFile.getOriginalFilename(),
           profileFile.getContentType(),
           profileFile.getBytes()
-      ));
+      );
+
+      // 성공 로그
+      log.info("[RESOLVE] status=SUCCESS, fileName={}, traceId={}",
+          LogUtils.maskFileName(profileFile.getOriginalFilename()), traceId);
+      return Optional.of(request);
     } catch (IOException e) {
+      log.error("[ERROR] Failed to read profile file: fileName={}, traceId={}",
+          LogUtils.maskFileName(profileFile.getOriginalFilename()), traceId, e);
       throw new RestException(ResultCode.FILE_PROCESSING_ERROR);
     }
   }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -4,8 +4,6 @@ import com.sprint.mission.discodeit.common.code.ResultCode;
 import com.sprint.mission.discodeit.dto2.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.notfound.BinaryContentNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.service.BinaryContentService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
@@ -33,11 +31,11 @@ public class BasicBinaryContentService implements BinaryContentService {
     byte[] bytes = request.bytes();
     String contentType = request.contentType();
 
-    BinaryContent binaryContent = new BinaryContent(
-        fileName,
-        (long) bytes.length,
-        contentType
-    );
+    BinaryContent binaryContent = BinaryContent.builder()
+        .fileName(fileName)
+        .size((long) bytes.length)
+        .contentType(contentType)
+        .build();
 
     // 실제 데이터 저장
     try {

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -16,8 +16,6 @@ import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
-import java.util.Collections;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -37,7 +35,11 @@ public class BasicChannelService implements ChannelService {
   @Override
   @Transactional
   public Channel createPrivateChannel(PrivateChannelCreateRequest request) {
-    Channel privateChannel = new Channel(ChannelType.PRIVATE, null, null);
+    Channel privateChannel = Channel.builder()
+        .type(ChannelType.PRIVATE)
+        .name(null)
+        .description(null)
+        .build();
     channelRepository.save(privateChannel);
 
     List<User> users = request.userIds().stream()
@@ -60,7 +62,11 @@ public class BasicChannelService implements ChannelService {
       throw new RestException(ResultCode.INVALID_CHANNEL_DATA);
     }
 
-    Channel publicChannel = new Channel(ChannelType.PUBLIC, request.name(), request.description());
+    Channel publicChannel = Channel.builder()
+        .type(ChannelType.PUBLIC)
+        .name(request.name())
+        .description(request.description())
+        .build();
     channelRepository.save(publicChannel);
     return publicChannel;
   }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -20,16 +20,19 @@ import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
-import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicChannelService implements ChannelService {
@@ -44,6 +47,13 @@ public class BasicChannelService implements ChannelService {
   @Override
   @Transactional
   public Channel createPrivateChannel(PrivateChannelCreateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[CREATE] status=START, participantIds={}, traceId={}",
+        log.isDebugEnabled() ? request.userIds() : LogUtils.maskUUIDList(request.userIds()),
+        traceId);
+
     Channel privateChannel = Channel.builder()
         .type(ChannelType.PRIVATE)
         .name(null)
@@ -53,21 +63,37 @@ public class BasicChannelService implements ChannelService {
 
     List<User> users = request.userIds().stream()
         .map(userId -> userRepository.findById(userId)
-            .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND)))
+            .orElseThrow(() -> {
+              log.warn("[CREATE] User not found for private channel: userId={}, traceId={}",
+                  LogUtils.maskUUID(userId), traceId);
+              return new RestException(ResultCode.USER_NOT_FOUND);
+            }))
         .toList();
 
     users.forEach(user -> {
       ReadStatus readStatus = new ReadStatus(user, privateChannel, privateChannel.getCreatedAt());
       readStatusRepository.save(readStatus);
+      log.info("[CREATE] ReadStatus created for user: userId={}, channelId={}, traceId={}",
+          LogUtils.maskUUID(user.getId()), LogUtils.maskUUID(privateChannel.getId()), traceId);
     });
 
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(privateChannel.getId()), traceId);
     return privateChannel;
   }
 
   @Override
   @Transactional
   public Channel createPublicChannel(PublicChannelCreateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[CREATE] status=START, channelName={}, traceId={}",
+        log.isDebugEnabled() ? request.name() : LogUtils.mask(request.name()), traceId);
+
     if (request.name().isBlank()) {
+      log.warn("[CREATE] Invalid Public Channel name: traceId={}", traceId);
       throw new RestException(ResultCode.INVALID_CHANNEL_DATA);
     }
 
@@ -77,21 +103,45 @@ public class BasicChannelService implements ChannelService {
         .description(request.description())
         .build();
     channelRepository.save(publicChannel);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(publicChannel.getId()), traceId);
     return publicChannel;
   }
 
   @Override
   @Transactional(readOnly = true)
   public Channel findById(UUID id) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? id : LogUtils.maskUUID(id), traceId);
+
     Channel channel = channelRepository.findById(id)
-        .orElseThrow(() -> new RestException(ResultCode.CHANNEL_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[FIND] Channel not found: channelId={}, traceId={}",
+              LogUtils.maskUUID(id), traceId);
+          return new RestException(ResultCode.CHANNEL_NOT_FOUND);
+        });
+
+    // 성공 로그
+    log.info("[FIND] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(id), traceId);
     return channel;
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<Channel> findAllByUserId(UUID userId) {
-    return channelRepository.findAll().stream()
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, userId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId), traceId);
+
+    List<Channel> channels = channelRepository.findAll().stream()
         .filter(channel -> {
           if (channel.getType() == ChannelType.PRIVATE) {
             List<UUID> userIds = readStatusRepository.findUsersByChannelId(channel.getId());
@@ -100,13 +150,28 @@ public class BasicChannelService implements ChannelService {
           return true; // PUBLIC이면 무조건 포함
         })
         .toList();
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, userId={}, channelCount={}, traceId={}",
+        LogUtils.maskUUID(userId), channels.size(), traceId);
+    return channels;
   }
 
   @Override
   @Transactional
   public Channel update(UUID channelId, PublicChannelUpdateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[UPDATE] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId), traceId);
+
     Channel channel = channelRepository.findById(channelId)
-        .orElseThrow(() -> new RestException(ResultCode.CHANNEL_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[UPDATE] Channel not found: channelId={}, traceId={}",
+              LogUtils.maskUUID(channelId), traceId);
+          return new RestException(ResultCode.CHANNEL_NOT_FOUND);
+        });
 
     if (channel.getType() == ChannelType.PRIVATE) {
       throw new RestException(ResultCode.INVALID_CHANNEL_TYPE);
@@ -118,12 +183,22 @@ public class BasicChannelService implements ChannelService {
 
     // 변경 감지 방식 적용(Dirty Checking)
     channel.updateChannel(ChannelType.PUBLIC, request.newName(), request.newDescription());
+
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(channelId), traceId);
     return channel;
   }
 
   @Override
   @Transactional
   public void delete(UUID id) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? id : LogUtils.maskUUID(id), traceId);
+
     Channel channel = channelRepository.findById(id)
         .orElseThrow(() -> new RestException(ResultCode.CHANNEL_NOT_FOUND));
 
@@ -134,11 +209,21 @@ public class BasicChannelService implements ChannelService {
     messageRepository.deleteAll(messages);
     readStatusRepository.deleteByChannelId(id);
     channelRepository.delete(channel);
+
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, channelId={}, traceId={}",
+        LogUtils.maskUUID(id), traceId);
   }
 
   @Override
   @Transactional(readOnly = true)
   public ChannelResponse getChannelResponse(Channel channel) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[RESPONSE] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? channel.getId() : LogUtils.maskUUID(channel.getId()), traceId);
+
     // 마지막 메시지 시간 조회
     Instant lastMessageAt = messageRepository.findFirstByChannelIdOrderByCreatedAtDesc(
             channel.getId())
@@ -164,6 +249,10 @@ public class BasicChannelService implements ChannelService {
           })
           .toList();
     }
+
+    // 성공 로그
+    log.info("[RESPONSE] status=SUCCESS, channelId={}, participantCount={}, traceId={}",
+        LogUtils.maskUUID(channel.getId()), participants.size(), traceId);
 
     return channelMapper.toResponse(channel, lastMessageAt, participants);
   }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -2,7 +2,6 @@ package com.sprint.mission.discodeit.service.basic;
 
 
 import com.sprint.mission.discodeit.common.code.ResultCode;
-import com.sprint.mission.discodeit.dto2.response.ChannelResponse;
 import com.sprint.mission.discodeit.dto2.request.PublicChannelUpdateRequest;
 import com.sprint.mission.discodeit.dto2.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.PublicChannelCreateRequest;
@@ -12,17 +11,14 @@ import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.notfound.ChannelNotFoundException;
-import com.sprint.mission.discodeit.exception.invalid.InvalidChannelTypeException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
-import com.sprint.mission.discodeit.mapper.ChannelMapper;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
+import java.util.Collections;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -60,6 +56,10 @@ public class BasicChannelService implements ChannelService {
   @Override
   @Transactional
   public Channel createPublicChannel(PublicChannelCreateRequest request) {
+    if (request.name().isBlank()) {
+      throw new RestException(ResultCode.INVALID_CHANNEL_DATA);
+    }
+
     Channel publicChannel = new Channel(ChannelType.PUBLIC, request.name(), request.description());
     channelRepository.save(publicChannel);
     return publicChannel;
@@ -97,9 +97,12 @@ public class BasicChannelService implements ChannelService {
       throw new RestException(ResultCode.INVALID_CHANNEL_TYPE);
     }
 
+    if (request.newName().isBlank()) {
+      throw new RestException(ResultCode.INVALID_CHANNEL_DATA);
+    }
+
     // 변경 감지 방식 적용(Dirty Checking)
     channel.updateChannel(ChannelType.PUBLIC, request.newName(), request.newDescription());
-//    channelRepository.save(channel);
     return channel;
   }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -15,8 +15,11 @@ import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.MessageService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import com.sprint.mission.discodeit.util.LogUtils;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,7 @@ import java.util.*;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicMessageService implements MessageService {
@@ -39,21 +43,48 @@ public class BasicMessageService implements MessageService {
   @Override
   @Transactional
   public Message create(MessageCreateRequest request, List<MultipartFile> attachments) {
+    String traceId = MDC.get("traceId");
+    UUID authorId = request.authorId();
+    UUID channelId = request.channelId();
+
+    // 시작 로그
+    log.info("[CREATE] status=START, authorId={}, channelId={}, traceId={}",
+        log.isDebugEnabled() ? authorId : LogUtils.maskUUID(authorId),
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId),
+        traceId);
+
     // 요청받은 id를 가진 Author, Channel이 있는지
-    User user = userRepository.findById(request.authorId())
-        .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND));
+    User user = userRepository.findById(authorId)
+        .orElseThrow(() -> {
+          log.warn("[CREATE] User not found: userId={}, traceId={}",
+              LogUtils.maskUUID(authorId), traceId);
+          return new RestException(ResultCode.USER_NOT_FOUND);
+        });
 
-    Channel channel = channelRepository.findById(request.channelId())
-        .orElseThrow(() -> new RestException(ResultCode.CHANNEL_NOT_FOUND));
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> {
+          log.warn("[CREATE] Channel not found: channelId={}, traceId={}",
+              LogUtils.maskUUID(channelId), traceId);
+          return new RestException(ResultCode.CHANNEL_NOT_FOUND);
+        });
 
+    // 첨부 파일 처리
     List<BinaryContent> binaryContents = new ArrayList<>();
     if (attachments != null) {
       for (MultipartFile attachment : attachments) {
+        String fileName = attachment.getOriginalFilename();
+        log.info("[CREATE] status=START, processing attachment: fileName={}, traceId={}",
+            log.isDebugEnabled() ? fileName : LogUtils.maskFileName(fileName), traceId);
+
         BinaryContent binaryContent = multipartFileMapper.toEntity(attachment);
         BinaryContent saved = binaryContentRepository.save(binaryContent);
         try {
           binaryContentStorage.put(saved.getId(), attachment.getBytes());
+          log.info("[CREATE] status=SUCCESS, contentId={}, traceId={}",
+              saved.getId(), traceId);
         } catch (IOException e) {
+          log.error("[ERROR] Failed to store BinaryContent: contentId={}, traceId={}",
+              saved.getId(), traceId, e);
           throw new RestException(ResultCode.FILE_PROCESSING_ERROR);
         }
         binaryContents.add(saved); // 저장된 객체 사용
@@ -66,37 +97,95 @@ public class BasicMessageService implements MessageService {
         .author(user)
         .attachments(binaryContents)
         .build();
-    return messageRepository.save(message);
+
+    messageRepository.save(message);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, messageId={}, attachmentCount={}, traceId={}",
+        message.getId(), binaryContents.size(), traceId);
+    return message;
   }
 
   @Override
   @Transactional(readOnly = true)
   public Message findById(UUID id) {
-    return messageRepository.findById(id)
-        .orElseThrow(() -> new RestException(ResultCode.MESSAGE_NOT_FOUND));
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND] status=START, messageId={}, traceId={}",
+        log.isDebugEnabled() ? id : LogUtils.maskUUID(id), traceId);
+
+    Message message = messageRepository.findById(id)
+        .orElseThrow(() -> {
+          log.warn("[FIND] Message not found: messageId={}, traceId={}",
+              LogUtils.maskUUID(id), traceId);
+          return new RestException(ResultCode.MESSAGE_NOT_FOUND);
+        });
+
+    // 성공 로그
+    log.info("[FIND] status=SUCCESS, messageId={}, traceId={}",
+        LogUtils.maskUUID(id), traceId);
+    return message;
   }
 
   @Override
   @Transactional(readOnly = true)
   public Slice<Message> findAllByChannelId(UUID channelId, Pageable pageable) {
-    return messageRepository.findByChannelIdOrderByCreatedAtDesc(channelId, pageable);
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, channelId={}, traceId={}",
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId), traceId);
+
+    Slice<Message> messages = messageRepository.findByChannelIdOrderByCreatedAtDesc(channelId,
+        pageable);
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, channelId={}, messageCount={}, traceId={}",
+        LogUtils.maskUUID(channelId), messages.getNumberOfElements(), traceId);
+    return messages;
   }
 
   @Override
   @Transactional
   public Message update(UUID messageId, MessageUpdateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[UPDATE] status=START, messageId={}, traceId={}",
+        log.isDebugEnabled() ? messageId : LogUtils.maskUUID(messageId), traceId);
+
     Message message = messageRepository.findById(messageId)
-        .orElseThrow(() -> new RestException(ResultCode.MESSAGE_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[UPDATE] Message not found: messageId={}, traceId={}",
+              LogUtils.maskUUID(messageId), traceId);
+          return new RestException(ResultCode.MESSAGE_NOT_FOUND);
+        });
+
     // Dirty checking
     message.updateMessage(request.newContent());
+
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, messageId={}, traceId={}",
+        LogUtils.maskUUID(messageId), traceId);
     return message;
   }
 
   @Override
   @Transactional
   public void delete(UUID id) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, messageId={}, traceId={}",
+        log.isDebugEnabled() ? id : LogUtils.maskUUID(id), traceId);
+
     Message message = messageRepository.findById(id)
-        .orElseThrow(() -> new RestException(ResultCode.MESSAGE_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[DELETE] Message not found: messageId={}, traceId={}",
+              LogUtils.maskUUID(id), traceId);
+          return new RestException(ResultCode.MESSAGE_NOT_FOUND);
+        });
 
     List<UUID> attachmentIds = message.getAttachments().stream()
         .map(BinaryContent::getId)
@@ -107,8 +196,13 @@ public class BasicMessageService implements MessageService {
     for (int i = 0; i < attachmentIds.size(); i += chunkSize) {
       List<UUID> chunk = attachmentIds.subList(i, Math.min(i + chunkSize, attachmentIds.size()));
       binaryContentRepository.deleteInBatch(chunk);
+      log.info("[DELETE] Deleted attachment chunk: chunkSize={}, traceId={}", chunk.size(),
+          traceId);
     }
 
     messageRepository.delete(message);
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, messageId={}, traceId={}",
+        LogUtils.maskUUID(id), traceId);
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -3,19 +3,12 @@ package com.sprint.mission.discodeit.service.basic;
 import com.sprint.mission.discodeit.common.code.ResultCode;
 import com.sprint.mission.discodeit.dto2.request.MessageCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.MessageUpdateRequest;
-import com.sprint.mission.discodeit.dto2.response.MessageResponse;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.notfound.ChannelNotFoundException;
-import com.sprint.mission.discodeit.exception.FileProcessingException;
-import com.sprint.mission.discodeit.exception.notfound.MessageNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
-import com.sprint.mission.discodeit.mapper.MessageMapper;
 import com.sprint.mission.discodeit.mapper.MultipartFileMapper;
-import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
@@ -26,11 +19,9 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -44,7 +35,6 @@ public class BasicMessageService implements MessageService {
   private final BinaryContentRepository binaryContentRepository;
   private final MultipartFileMapper multipartFileMapper;
   private final BinaryContentStorage binaryContentStorage;
-  private final MessageMapper messageMapper;
 
   @Override
   @Transactional
@@ -70,13 +60,12 @@ public class BasicMessageService implements MessageService {
       }
     }
 
-    Message message = new Message(
-        request.content(),
-        channel,
-        user,
-        binaryContents
-    );
-
+    Message message = Message.builder()
+        .content(request.content())
+        .channel(channel)
+        .author(user)
+        .attachments(binaryContents)
+        .build();
     return messageRepository.save(message);
   }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -7,10 +7,6 @@ import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.notfound.ChannelNotFoundException;
-import com.sprint.mission.discodeit.exception.duplicate.DuplicateReadStatusException;
-import com.sprint.mission.discodeit.exception.notfound.ReadStatusNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
@@ -20,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,8 +38,12 @@ public class BasicReadStatusService implements ReadStatusService {
     Channel channel = channelRepository.findById(request.channelId())
         .orElseThrow(() -> new RestException(ResultCode.CHANNEL_NOT_FOUND));
 
-    ReadStatus newReadStatus = new ReadStatus(user, channel,
-        request.lastReadAt());
+    ReadStatus newReadStatus = ReadStatus.builder()
+        .user(user)
+        .channel(channel)
+        .lastReadAt(request.lastReadAt())
+        .build();
+
     return readStatusRepository.save(newReadStatus);
   }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -11,14 +11,18 @@ import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.ReadStatusService;
+import com.sprint.mission.discodeit.util.LogUtils;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicReadStatusService implements ReadStatusService {
@@ -31,12 +35,30 @@ public class BasicReadStatusService implements ReadStatusService {
   @Override
   @Transactional
   public ReadStatus create(ReadStatusCreateRequest request) {
-    // 관련된 User와 Channel이 존재하는지 확인
-    User user = userRepository.findById(request.userId())
-        .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND));
+    String traceId = MDC.get("traceId");
+    UUID userId = request.userId();
+    UUID channelId = request.channelId();
 
-    Channel channel = channelRepository.findById(request.channelId())
-        .orElseThrow(() -> new RestException(ResultCode.CHANNEL_NOT_FOUND));
+    // 시작 로그
+    log.info("[CREATE] status=START, userId={}, channelId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId),
+        log.isDebugEnabled() ? channelId : LogUtils.maskUUID(channelId),
+        traceId);
+
+    // 관련된 User와 Channel이 존재하는지 확인
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> {
+          log.warn("[CREATE] User not found: userId={}, traceId={}",
+              LogUtils.maskUUID(userId), traceId);
+          return new RestException(ResultCode.USER_NOT_FOUND);
+        });
+
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> {
+          log.warn("[CREATE] Channel not found: channelId={}, traceId={}",
+              LogUtils.maskUUID(channelId), traceId);
+          return new RestException(ResultCode.CHANNEL_NOT_FOUND);
+        });
 
     ReadStatus newReadStatus = ReadStatus.builder()
         .user(user)
@@ -44,33 +66,78 @@ public class BasicReadStatusService implements ReadStatusService {
         .lastReadAt(request.lastReadAt())
         .build();
 
-    return readStatusRepository.save(newReadStatus);
+    readStatusRepository.save(newReadStatus);
+
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, readStatusId={}, traceId={}",
+        newReadStatus.getId(), traceId);
+    return newReadStatus;
   }
 
   // ID로 ReadStatus 조회
   @Override
   @Transactional(readOnly = true)
   public ReadStatus findById(UUID readStatusId) {
-    return readStatusRepository.findById(readStatusId)
-        .orElseThrow(() -> new RestException(ResultCode.READ_STATUS_NOT_FOUND));
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND] status=START, readStatusId={}, traceId={}",
+        log.isDebugEnabled() ? readStatusId : LogUtils.maskUUID(readStatusId), traceId);
+
+    ReadStatus readStatus = readStatusRepository.findById(readStatusId)
+        .orElseThrow(() -> {
+          log.warn("[FIND] ReadStatus not found: readStatusId={}, traceId={}",
+              LogUtils.maskUUID(readStatusId), traceId);
+          return new RestException(ResultCode.READ_STATUS_NOT_FOUND);
+        });
+
+    // 성공 로그
+    log.info("[FIND] status=SUCCESS, readStatusId={}, traceId={}",
+        LogUtils.maskUUID(readStatusId), traceId);
+    return readStatus;
   }
 
   // 사용자의 Id로 조회
   @Override
   @Transactional(readOnly = true)
   public List<ReadStatus> findAllByUserId(UUID userId) {
-    return readStatusRepository.findAllByUserId(userId);
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, userId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId), traceId);
+
+    List<ReadStatus> readStatuses = readStatusRepository.findAllByUserId(userId);
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, userId={}, readStatusCount={}, traceId={}",
+        LogUtils.maskUUID(userId), readStatuses.size(), traceId);
+    return readStatuses;
   }
 
   // ReadStatus 업데이트
   @Override
   @Transactional
   public ReadStatus update(UUID readStatusId, ReadStatusUpdateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[UPDATE] status=START, readStatusId={}, traceId={}",
+        log.isDebugEnabled() ? readStatusId : LogUtils.maskUUID(readStatusId), traceId);
+
     Instant newLastReadAt = request.newLastReadAt();
     ReadStatus readStatus = readStatusRepository.findById(readStatusId)
-        .orElseThrow(() -> new RestException(ResultCode.READ_STATUS_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[UPDATE] ReadStatus not found: readStatusId={}, traceId={}",
+              LogUtils.maskUUID(readStatusId), traceId);
+          return new RestException(ResultCode.READ_STATUS_NOT_FOUND);
+        });
 
     readStatus.updateReadStatus(newLastReadAt);
+
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, readStatusId={}, traceId={}",
+        LogUtils.maskUUID(readStatusId), traceId);
     return readStatus;
   }
 
@@ -78,10 +145,23 @@ public class BasicReadStatusService implements ReadStatusService {
   @Override
   @Transactional
   public void delete(UUID readStatusId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, readStatusId={}, traceId={}",
+        log.isDebugEnabled() ? readStatusId : LogUtils.maskUUID(readStatusId), traceId);
+
     ReadStatus readStatus = readStatusRepository.findById(readStatusId)
-        .orElseThrow(() -> new RestException(ResultCode.READ_STATUS_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[DELETE] ReadStatus not found: readStatusId={}, traceId={}",
+              LogUtils.maskUUID(readStatusId), traceId);
+          return new RestException(ResultCode.READ_STATUS_NOT_FOUND);
+        });
 
     readStatusRepository.delete(readStatus);
-  }
 
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, readStatusId={}, traceId={}",
+        LogUtils.maskUUID(readStatusId), traceId);
+  }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -16,8 +16,11 @@ import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.UserService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import com.sprint.mission.discodeit.util.LogUtils;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -25,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicUserService implements UserService {
@@ -39,6 +43,16 @@ public class BasicUserService implements UserService {
   @Transactional
   public User create(UserCreateRequest userCreateRequest,
       Optional<BinaryContentCreateRequest> optionalProfileCreateRequest) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[CREATE] status=START, username={}, email={}, traceId={}",
+        log.isDebugEnabled() ? userCreateRequest.username()
+            : LogUtils.mask(userCreateRequest.username()),
+        log.isDebugEnabled() ? userCreateRequest.email()
+            : LogUtils.maskEmail(userCreateRequest.email()),
+        traceId);
+
     // 예외처리
     validateDuplicate(userCreateRequest.username(), userCreateRequest.email());
 
@@ -56,30 +70,72 @@ public class BasicUserService implements UserService {
 
     userStatusRepository.save(new UserStatus(newUser, Instant.now()));
 
+    // 성공 로그
+    log.info("[CREATE] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(newUser.getId()), traceId);
     return newUser;
   }
 
   @Override
   @Transactional(readOnly = true)
-  public User findById(UUID id) {
+  public User findById(UUID userId) {
+    String traceId = MDC.get("traceId");
 
-    return userRepository.findById(id)
-        .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND));
+    // 시작 로그
+    log.info("[FIND] status=START, userId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId), traceId);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> {
+          log.warn("[FIND] User not found: userId={}, traceId={}",
+              LogUtils.maskUUID(userId), traceId);
+          return new RestException(ResultCode.USER_NOT_FOUND);
+        });
+
+    // 성공 로그
+    log.info("[FIND] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(user.getId()), traceId);
+    return user;
   }
 
 
   @Override
   @Transactional(readOnly = true)
   public List<User> findAll() {
-    return userRepository.findAll();
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[FIND_ALL] status=START, traceId={}", traceId);
+
+    List<User> users = userRepository.findAll();
+
+    // 성공 로그
+    log.info("[FIND_ALL] status=SUCCESS, userCount={}, traceId={}",
+        users.size(), traceId);
+    return users;
   }
 
   @Override
   @Transactional
   public User update(UUID userId, UserUpdateRequest userUpdateRequest,
       Optional<BinaryContentCreateRequest> optionalProfileCreateRequest) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[UPDATE] status=START, userId={}, newUsername={}, newEmail={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId),
+        log.isDebugEnabled() ? userUpdateRequest.newUsername()
+            : LogUtils.mask(userUpdateRequest.newUsername()),
+        log.isDebugEnabled() ? userUpdateRequest.newEmail()
+            : LogUtils.maskEmail(userUpdateRequest.newEmail()),
+        traceId);
+
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[UPDATE] User not found: userId={}, traceId={}",
+              LogUtils.maskUUID(userId), traceId);
+          return new RestException(ResultCode.USER_NOT_FOUND);
+        });
 
     String newUsername = userUpdateRequest.newUsername();
     String newEmail = userUpdateRequest.newEmail();
@@ -99,35 +155,77 @@ public class BasicUserService implements UserService {
     String newPassword = userUpdateRequest.newPassword();
     user.updateUser(newUsername, newEmail, newPassword, newProfile);
 
+    // 성공 로그
+    log.info("[UPDATE] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(userId), traceId);
     return user;
   }
 
   @Override
   @Transactional
-  public void delete(UUID id) {
+  public void delete(UUID userId) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[DELETE] status=START, userId={}, traceId={}",
+        log.isDebugEnabled() ? userId : LogUtils.maskUUID(userId), traceId);
+
     // 사용자 존재 여부 확인
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new RestException(ResultCode.USER_NOT_FOUND));
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> {
+          log.warn("[DELETE] User not found: userId={}, traceId={}",
+              LogUtils.maskUUID(userId), traceId);
+          return new RestException(ResultCode.USER_NOT_FOUND);
+        });
 
     // 관련 데이터 삭제 (프로필 이미지, 유저 상태)
     Optional.ofNullable(user.getProfile())
         .ifPresent(binaryContentRepository::delete);
+
     // 최종적으로 사용자 삭제
     userRepository.delete(user);
+
+    // 성공 로그
+    log.info("[DELETE] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(userId), traceId);
   }
 
   // email과 username 중복 체크
   private void validateDuplicate(String username, String email) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[VALIDATE] status=START, username={}, email={}, traceId={}",
+        log.isDebugEnabled() ? username : LogUtils.mask(username),
+        log.isDebugEnabled() ? email : LogUtils.maskEmail(email),
+        traceId);
+
     if (userRepository.existsByUsername(username)) {
+      log.warn("[VALIDATE] Duplicate username detected: username={}, traceId={}",
+          username, traceId);
       throw new RestException(ResultCode.DUPLICATE_USERNAME);
     }
+
     if (userRepository.existsByEmail(email)) {
+      log.warn("[VALIDATE] Duplicate email detected: email={}, traceId={}",
+          LogUtils.maskEmail(email), traceId);
       throw new RestException(ResultCode.DUPLICATE_EMAIL);
     }
+
+    // 성공 로그
+    log.info("[VALIDATE] status=SUCCESS, username={}, email={}, traceId={}",
+        LogUtils.mask(username), LogUtils.maskEmail(email), traceId);
   }
 
   // BianryContent 생성 로직
   private BinaryContent saveBinaryContent(BinaryContentCreateRequest request) {
+    String traceId = MDC.get("traceId");
+
+    // 시작 로그
+    log.info("[SAVE] status=START, fileName={}, traceId={}",
+        log.isDebugEnabled() ? request.fileName() : LogUtils.maskFileName(request.fileName()),
+        traceId);
+
     BinaryContent content = new BinaryContent(
         request.fileName(),
         (long) request.bytes().length,
@@ -137,10 +235,14 @@ public class BasicUserService implements UserService {
     // 먼저 DB에 저장해서 ID를 생성
     BinaryContent savedContent = binaryContentRepository.save(content);
 
-    // ID가 생긴 후에야 파일 저장 가능
     try {
+      // 파일 저장
       binaryContentStorage.put(savedContent.getId(), request.bytes());
+      log.info("[SAVE] BinaryContent saved successfully: contentId={}, traceId={}",
+          savedContent.getId(), traceId);
     } catch (Exception e) {
+      log.error("[SAVE] Error saving binary content: contentId={}, traceId={}",
+          savedContent.getId(), traceId, e);
       throw new RestException(ResultCode.FILE_PROCESSING_ERROR);
     }
 
@@ -153,6 +255,10 @@ public class BasicUserService implements UserService {
     boolean isOnline = user.getLastActiveAt() != null &&
         user.getLastActiveAt()
             .isAfter(Instant.now().minusSeconds(CodeitConstants.ONLINE_THRESHOLD_SECONDS));
+
+    // 성공 로그
+    log.info("[RESPONSE] status=SUCCESS, userId={}, traceId={}",
+        LogUtils.maskUUID(user.getId()), MDC.get("traceId"));
     return userMapper.toResponse(user, isOnline);
   }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -1,13 +1,16 @@
 package com.sprint.mission.discodeit.service.basic;
 
+import com.sprint.mission.discodeit.common.CodeitConstants;
 import com.sprint.mission.discodeit.common.code.ResultCode;
 import com.sprint.mission.discodeit.dto2.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.UserCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.UserUpdateRequest;
+import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.exception.RestException;
+import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
@@ -30,6 +33,7 @@ public class BasicUserService implements UserService {
   private final BinaryContentRepository binaryContentRepository;
   private final UserStatusRepository userStatusRepository;
   private final BinaryContentStorage binaryContentStorage;
+  private final UserMapper userMapper;
 
   @Override
   @Transactional
@@ -141,6 +145,15 @@ public class BasicUserService implements UserService {
     }
 
     return savedContent;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public UserResponse getUserResponse(User user) {
+    boolean isOnline = user.getLastActiveAt() != null &&
+        user.getLastActiveAt()
+            .isAfter(Instant.now().minusSeconds(CodeitConstants.ONLINE_THRESHOLD_SECONDS));
+    return userMapper.toResponse(user, isOnline);
   }
 
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -1,22 +1,13 @@
 package com.sprint.mission.discodeit.service.basic;
 
-import com.sprint.mission.discodeit.common.CodeitConstants;
 import com.sprint.mission.discodeit.common.code.ResultCode;
 import com.sprint.mission.discodeit.dto2.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto2.request.UserCreateRequest;
-import com.sprint.mission.discodeit.dto2.response.BinaryContentResponse;
-import com.sprint.mission.discodeit.dto2.response.UserResponse;
 import com.sprint.mission.discodeit.dto2.request.UserUpdateRequest;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.duplicate.DuplicateEmailException;
-import com.sprint.mission.discodeit.exception.duplicate.DuplicateUsernameException;
-import com.sprint.mission.discodeit.exception.notfound.BinaryContentNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
-import com.sprint.mission.discodeit.mapper.BinaryContentMapper;
-import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
@@ -52,12 +43,12 @@ public class BasicUserService implements UserService {
         .map(this::saveBinaryContent)
         .orElse(null);
 
-    User newUser = userRepository.save(new User(
-        userCreateRequest.username(),
-        userCreateRequest.email(),
-        userCreateRequest.password(),
-        newProfile
-    ));
+    User newUser = User.builder()
+        .username(userCreateRequest.username())
+        .email(userCreateRequest.email())
+        .password(userCreateRequest.password())
+        .profile(newProfile)
+        .build();
 
     userStatusRepository.save(new UserStatus(newUser, Instant.now()));
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
@@ -7,8 +7,6 @@ import com.sprint.mission.discodeit.dto2.request.UserStatusUpdateRequest;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.exception.RestException;
-import com.sprint.mission.discodeit.exception.notfound.UserNotFoundException;
-import com.sprint.mission.discodeit.exception.notfound.UserStatusNotFoundException;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.UserStatusService;
@@ -40,7 +38,11 @@ public class BasicUserStatusService implements UserStatusService {
       throw new RestException(ResultCode.USER_STATUS_NOT_FOUND);
     }
 
-    UserStatus userStatus = new UserStatus(user, request.lastAccessedAt());
+    UserStatus userStatus = UserStatus.builder()
+        .user(user)
+        .lastActiveAt(request.lastAccessedAt())
+        .build();
+
     return userStatusRepository.save(userStatus);
   }
 

--- a/src/main/java/com/sprint/mission/discodeit/util/LogUtils.java
+++ b/src/main/java/com/sprint/mission/discodeit/util/LogUtils.java
@@ -1,0 +1,61 @@
+package com.sprint.mission.discodeit.util;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(LogUtils.class);
+
+  private static boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  public static String mask(String input) {
+    if (isDebugEnabled() || input == null || input.length() < 3) {
+      return input;
+    }
+    return input.substring(0, 1) + "***" + input.substring(input.length() - 1);
+  }
+
+  public static String maskUUID(UUID uuid) {
+    if (isDebugEnabled() || uuid == null) {
+      return uuid != null ? uuid.toString() : "***";
+    }
+    String uuidString = uuid.toString();
+    return uuidString.substring(0, 4) + "****" + uuidString.substring(uuidString.length() - 4);
+  }
+
+  public static String maskUUIDList(List<UUID> uuids) {
+    if (uuids == null || uuids.isEmpty()) {
+      return "[]";
+    }
+    return uuids.stream()
+        .map(LogUtils::maskUUID)
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+
+  public static String maskEmail(String email) {
+    if (isDebugEnabled() || email == null || email.length() < 5 || !email.contains("@")) {
+      return email;
+    }
+    String[] parts = email.split("@");
+    return mask(parts[0]) + "@" + parts[1];
+  }
+
+  public static String maskFileName(String fileName) {
+    if (isDebugEnabled() || fileName == null || fileName.length() < 3) {
+      return fileName;
+    }
+    int dotIndex = fileName.lastIndexOf(".");
+    if (dotIndex > 0) {
+      String name = fileName.substring(0, dotIndex);
+      String extension = fileName.substring(dotIndex);
+      return mask(name) + extension;
+    }
+    return mask(fileName);
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    active: dev
+  datasource:
+    url: jdbc:postgresql://localhost:5432/discodeit_dev
+    username: dev_user
+    password: dev_password
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+server:
+  port: 8080
+logging:
+  level:
+    root: debug
+    com.sprint.mission.discodeit: debug

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,6 @@
 spring:
-  profiles:
-    active: dev
   datasource:
+    driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/discodeit_dev
     username: dev_user
     password: dev_password
@@ -9,8 +8,10 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
 server:
-  port: 8080
+  port: 8081
+
 logging:
   level:
     root: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,6 @@
 spring:
-  profiles:
-    active: prod
   datasource:
+    driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/discodeit_prod
     username: prod_user
     password: prod_password
@@ -9,8 +8,10 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+
 server:
-  port: 8081
+  port: 8082
+
 logging:
   level:
     root: info

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    active: prod
+  datasource:
+    url: jdbc:postgresql://localhost:5432/discodeit_prod
+    username: prod_user
+    password: prod_password
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+server:
+  port: 8081
+logging:
+  level:
+    root: info
+    com.sprint.mission.discodeit: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,16 +2,11 @@ spring:
   application:
     name: discodeit
   datasource:
-    url: jdbc:postgresql://localhost:5432/discodeit
-    username: discodeit_user
-    password: discodeit1234
     driver-class-name: org.postgresql.Driver
   jpa:
-    hibernate:
-      ddl-auto: validate # or update / none
-    show-sql: true       # 콘솔에 SQL 출력
     properties:
-      format_sql: true # SQL 예쁘게 출력
+      hibernate:
+        format_sql: true # SQL 예쁘게 출력
 
 
 discodeit:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,23 @@ spring:
   application:
     name: discodeit
   datasource:
+    url: jdbc:postgresql://localhost:5432/discodeit
+    username: discodeit_user
+    password: discodeit1234
     driver-class-name: org.postgresql.Driver
-  jpa:
-    properties:
-      hibernate:
-        format_sql: true # SQL 예쁘게 출력
+    #  profiles:
+    #    active: dev # dev | prod
 
+  jpa:
+    hibernate:
+      ddl-auto: validate # or update / none
+    show-sql: true       # 콘솔에 SQL 출력
+    properties:
+      format_sql: true # SQL 예쁘게 출력
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 30MB
 
 discodeit:
   repository:
@@ -18,3 +29,46 @@ discodeit:
     local:
       root-path: ./binary-storage
 
+logging:
+  level:
+    root: info
+    com.sprint.mission.discodeit: info
+
+# Actuator 엔드포인트 설정
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, loggers
+    health:
+      show-details: always
+  # 명시적으로 info에 나타날 정보 활성화
+  info:
+    os:
+      enabled: true
+    java:
+      enabled: true
+    env:
+      enabled: true
+
+info:
+  app:
+    name: Discodeit
+    version: 1.7.0
+    java:
+      version: 17
+    spring:
+      boot:
+        version: 3.4.0
+  settings:
+    datasource:
+      url: ${spring.datasource.url}
+      driver-class-name: ${spring.datasource.driver-class-name}
+    jpa:
+      ddl-auto: ${spring.jpa.hibernate.ddl-auto}
+    storage:
+      type: ${discodeit.storage.type}
+      path: ${discodeit.storage.local.root-path}
+    multipart:
+      max-file-size: ${spring.servlet.multipart.max-file-size}
+      max-request-size: ${spring.servlet.multipart.max-request-size}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <!-- 콘솔 출력 -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId}] %logger{36} - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <!-- 파일 출력 -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>.logs/discodeit.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>.logs/discodeit-%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>3GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId}] %logger{36} - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <!-- Logger 설정 -->
+  <logger name="com.sprint.mission.discodeit" level="debug" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </logger>
+
+  <!-- 기본 Logger 설정 -->
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
# 기본 요구사항 체크리스트

## 프로파일 기반 설정 관리

- [x] 개발, 운영 환경에 대한 프로파일을 구성하세요.
- [x] `application-dev.yaml`, `application-prod.yaml` 파일을 생성하세요.
- [x] 다음과 같은 설정값을 프로파일별로 분리하세요:
  - [x] 데이터베이스 연결 정보
  - [x] 서버 포트

## 로그 관리

- [x] Lombok의 `@Slf4j` 어노테이션을 활용해 로깅을 쉽게 추가할 수 있도록 구성하세요.
- [x] `application.yaml`에 기본 로깅 레벨을 설정하세요.
  - [x] 기본적으로 info 레벨로 설정합니다.
- [x] 환경별 적절한 로깅 레벨을 프로파일 별로 설정해보세요.
  - [x] SQL 로그를 보기 위해 설정했던 레벨은 유지합니다.
  - [x] 우리가 작성한 프로젝트의 로그는 개발 환경에서 debug, 운영 환경에서는 info 레벨로 설정합니다.
- [x] Spring Boot의 기본 로깅 구현체인 Logback의 설정 파일을 구성하세요.
  - [x] `logback-spring.xml` 파일을 생성하세요.
  - [x] 다음 예시와 같은 로그 메시지를 출력하기 위한 로깅 패턴과 출력 방식을 커스터마이징하세요.
    - # 패턴
      `{년}-{월}-{일} {시}:{분}:{초}:{밀리초} [{스레드명}] {로그 레벨(5글자로 맞춤)} {로거 이름(최대 36글자)} - {로그 메시지}{줄바꿈}`
    - # 예시
      `25-01-01 10:33:55.740 [main] DEBUG c.s.m.discodeit.DiscodeitApplication - Running with Spring Boot v3.4.0, Spring v6.2.0`
  - [x] 콘솔과 파일에 동시에 로그를 기록하도록 설정하세요.
  - [x] 파일은 `{프로젝트 루트}/.logs` 경로에 저장되도록 설정하세요.
  - [x] 로그 파일은 일자별로 롤링되도록 구성하세요.
  - [x] 로그 파일은 30일간 보관하도록 구성하세요.

## 서비스 레이어와 컨트롤러 레이어의 주요 메소드에 로깅을 추가하세요

- [x] 로깅 레벨을 적절히 사용하세요: `ERROR`, `WARN`, `INFO`, `DEBUG`
  - [x] 사용자 생성/수정/삭제
  - [x] 채널 생성/수정/삭제
  - [x] 메시지 생성/수정/삭제
  - [x] 파일 업로드/다운로드

## 예외 처리 고도화

- [ ] 커스텀 예외를 설계하고 구현하세요.
  - [ ] 패키지명: `com.sprint.mission.discodeit.exception[.{도메인}]`
- [ ] `ErrorCode` Enum 클래스를 통해 예외 코드명과 메시지를 정의하세요.
- [ ] 모든 예외의 기본이 되는 `DiscodeitException` 클래스를 정의하세요.
  - [ ] 클래스 다이어그램
  - [ ] details는 예외 발생 상황에 대한 추가정보를 저장하기 위한 속성입니다.
- [ ] DiscodeitException을 상속하는 주요 도메인 별 메인 예외 클래스를 정의하세요.
  - UserException, ChannelException 등
  - 실제로 활용되는 클래스라기보다는 예외 클래스의 계층 구조를 명확하게 하기 위한 클래스입니다.
- [ ] 도메인 메인 예외 클래스를 상속하는 구체적인 예외 클래스를 정의하세요.
  - UserNotFoundException, UserAlreadyExistException 등 필요한 예외를 정의하세요.
- [ ] 기존에 구현했던 예외를 커스텀 예외로 대체하세요.
  - NoSuchElementException
  - IllegalArgumentException
  - …
- [ ] `ErrorResponse`를 통해 일관된 예외 응답을 정의하세요.
  - 클래스 다이어그램
    - int status: HTTP 상태코드
    - String exceptionType: 발생한 예외의 클래스 이름
- [ ] 앞서 정의한 `ErrorResponse`와 `@RestControllerAdvice`를 활용해 예외를 처리하는 예외 핸들러를 구현하세요.
  - 모든 핸들러는 일관된 응답(ErrorResponse)을 가져야 합니다.

## 유효성 검사

- [x] Spring Validation 의존성을 추가하세요.
- [x] 주요 Request DTO에 제약 조건 관련 어노테이션을 추가하세요.
  - `@NotNull`, `@NotBlank`, `@Size`, `@Email` 등
- [x] 컨트롤러에 `@Valid`를 사용해 요청 데이터를 검증하세요.
- [x] 검증 실패 시 발생하는 MethodArgumentNotValidException을 전역 예외 핸들러에서 처리하세요.
- [x] 유효성 검증 실패 시 상세한 오류 메시지를 포함한 응답을 반환하세요.

## Actuator

- [x] Spring Boot Actuator 의존성을 추가하세요.
- [x] 기본 Actuator 엔트포인트를 설정하세요.
  - health, info, metrics, loggers
- [x] Actuator info를 위한 애플리케이션 정보를 추가하세요.
  - 애플리케이션 이름: Discodeit
  - 애플리케이션 버전: 1.7.0
  - 자바 버전: 17
  - 스프링 부트 버전: 3.4.0
  - 주요 설정 정보
- [x] Spring Boot 서버를 실행 후 각종 정보를 확인해보세요.
  - `/actuator/info`
  - `/actuator/metrics`
  - `/actuator/health`
  - `/actuator/loggers`

## 단위 테스트

- [x] 서비스 레이어의 주요 메소드에 대한 단위 테스트를 작성하세요.
  - [x] 다음 서비스의 핵심 메소드에 대해 각각 최소 2개 이상(성공, 실패)의 테스트 케이스를 작성하세요.
  - [x] `UserService`: create, update, delete 메소드
  - [x] `ChannelService`: create(PUBLIC, PRIVATE), update, delete, findByUserId 메소드
  - [x] `MessageService`: create, update, delete, findByChannelId 메소드
- [x] Mockito를 활용해 Repository 의존성을 모의(mock)하세요.
- [x] BDDMockito를 활용해 테스트 가독성을 높이세요.

## 슬라이스 테스트

- [x] 레포지토리 레이어의 슬라이스 테스트를 작성하세요.
  - [x] `@DataJpaTest`를 활용해 테스트를 구현하세요.
  - [x] 테스트 환경을 구성하는 프로파일을 구성하세요.
  - [x] `application-test.yaml`을 생성하세요.
  - [x] 데이터소스는 H2 인메모리 데이터 베이스를 사용하고, PostgreSQL 호환 모드로 설정하세요.
  - [x] H2 데이터베이스를 위해 필요한 의존성을 추가하세요.
  - [x] 테스트 시작 시 스키마를 새로 생성하도록 설정하세요.
  - [x] 디버깅에 용이하도록 로그 레벨을 적절히 설정하세요.
- [x] 테스트 실행 간 test 프로파일을 활성화 하세요.
- [x] JPA Audit 기능을 활성화 하기 위해 테스트 클래스에 `@EnableJpaAuditing`을 추가하세요.
- [x] 주요 레포지토리(User, Channel, Message)의 주요 쿼리 메소드에 대해 각각 최소 2개 이상(성공, 실패)의 테스트 케이스를 작성하세요.
- [x] 커스텀 쿼리 메소드
- [x] 페이징 및 정렬 메소드
- [x] 컨트롤러 레이어의 슬라이스 테스트를 작성하세요.
  - [x] `@WebMvcTest`를 활용해 테스트를 구현하세요.
  - [x] `WebMvcTest`에서 자동으로 등록되지 않는 유형의 Bean이 필요하다면 `@Import`를 활용해 추가하세요.
    - 예시: `@Import({ErrorCodeStatusMapper.class})`
- [x] 주요 컨트롤러(User, Channel, Message)에 대해 최소 2개 이상(성공, 실패)의 테스트 케이스를 작성하세요.
- [x] MockMvc를 활용해 컨트롤러를 테스트하세요.
- [x] 서비스 레이어를 모의(mock)하여 컨트롤러 로직만 테스트하세요.
- [x] JSON 응답을 검증하는 테스트를 포함하세요.

## 통합 테스트

- [ ] 통합 테스트 환경을 구성하세요.
  - [] `@SpringBootTest`를 활용해 Spring 애플리케이션 컨텍스트를 로드하세요.
  - [] H2 인메모리 데이터베이스를 활용하세요.
  - [] 테스트용 프로파일을 구성하세요.
- [ ] 주요 API 엔드포인트에 대한 통합 테스트를 작성하세요.
  - [ ] 주요 API에 대해 최소 2개 이상의 테스트 케이스를 작성하세요.
  - [x] 사용자 관련 API (생성, 수정, 삭제, 목록 조회)
  - [ ] 채널 관련 API (생성, 수정, 삭제)
  - [ ] 메시지 관련 API (생성, 수정, 삭제, 목록 조회)
- [ ] 각 테스트는 `@Transactional`을 활용해 독립적으로 실행하세요.

---
## 멘토에게
![image](https://github.com/user-attachments/assets/4138b4af-ecf7-4a5e-85d6-4bd9250f7f3c)

#### 예외 처리
기존에 사용하고 있던 예외 처리 방식이 있어서 별도의 에러 처리를 변경하지 않았습니다.

전역 예외 처리를 GlobalExceptionHandler에서 진행하고 있고 응답 형식을 ErrorResponse라는 dto를 통해 통일하고 있습니다.
또한, 커스텀 예외를 RestException으로 처리하고 있으며, common/code에 위치하고 있는 ResultCode를 통해 발생하는 오류를 작성해 놓고 예상되는 에러와 그에 대한 응답을 일관되게 관리하고 있습니다.

#### 통합 테스트 질문
테스트를 제대로 구성하지 못한 것 같습니다.
특히 통합테스트는 사용자 관련 API 테스트만 작성했으며(UserApiIntergraionTest.java), 내부 트랜잭션 처리에 문제가 있는 것 같습니다.

각 테스트에 @Transcational을 활용해서 독립적으로 실행하려 했으나, 작성한 getUsers_success, updateUserWithProfile_success 테스트에서 데이터 불일치 문제가 발생했습니다.

@Transcational만 사용한 경우에는 createUser_success에서 생성한 testuser만 조회되고, 이후 추가된 User(john, jane)은 조회되지 않는 현상이 있었습니다. 이로 인해 getUsers_success와 updateUserWithProfile_success에서 원하는 데이터가 조회되지 않고 테스트에 실패하게 되었습니다.

해결을 위해 트랜잭션 범위 조정, entityManger.flush() entitiyManager.clear()를 통해 변경사항을 즉시 반영하려 시도해 보았습니다.
현재는 컨텍스트를 초기화하기 위해 @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)를 사용하여 문제를 회피하고 있습니다. 그러나 이 방법은 실행도 너무 오래 걸리고 근본적인 해결책이 아닌 것 같습니다.

WebTestClient를 사용하는 경우, 트랜잭션 범위가 분리되어 문제가 발생하는 것 같은데. 이를 해결할 방법이 있을까요? 아니면 테스트가 아닌 프로젝트 구성을 변경해야 할까요?
UserRepository.save()로 저장된 데이터가 WebTestClient에서 조회되지 않는 이유가 궁금합니다.

![image](https://github.com/user-attachments/assets/d43bed33-d311-4eab-88c0-d236104e1329)
![image](https://github.com/user-attachments/assets/4e4894b2-8a32-4c58-b601-51d8c63bae2b)

- 확인된 에러 로그
Users List: [UserResponse[id=ccc4f2c3-43b7-4714-9a79-9c4b9b37fa01, createdAt=2025-05-17T21:11:26.871481Z, updatedAt=2025-05-17T21:11:26.871481Z, username=testuser, email=test@email.com, profile=BinaryContentResponse[id=626d0a8d-c69d-48f5-b9a6-fd267324811b, fileName=sample-profile.png, size=9534, contentType=image/png, bytes=[B@7855b359], online=false]]
