### PR TITLE
[정종현] sprint11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'com.nimbusds:nimbus-jose-jwt:10.3'
-
+    implementation 'org.springframework.retry:spring-retry:2.0.12'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.15.1'
+    
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.mapstruct:mapstruct:1.6.3'

--- a/src/main/java/com/sprint/mission/discodeit/config/AsyncConfig.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.concurrent.DelegatingSecurityContextExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  private static final int CORE_POOL_SIZE = 5;
+  private static final int MAXIMUM_POOL_SIZE = 10;
+  private static final int QUEUE_CAPACITY = 25;
+
+  @Bean(name = "taskExecutor")
+  public Executor taskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(CORE_POOL_SIZE);
+    executor.setMaxPoolSize(MAXIMUM_POOL_SIZE);
+    executor.setQueueCapacity(QUEUE_CAPACITY);
+    executor.setThreadNamePrefix("Async-");
+    // Task Decorator 적용 (MDC 전파)
+    executor.setTaskDecorator(new ContextTaskDecorator());
+    executor.initialize();
+
+    // SecurityContext 전파를 위한 래핑
+    return new DelegatingSecurityContextExecutor(executor);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/config/ContextTaskDecorator.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/ContextTaskDecorator.java
@@ -1,0 +1,33 @@
+package com.sprint.mission.discodeit.config;
+
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class ContextTaskDecorator implements TaskDecorator {
+
+  @Override
+  public Runnable decorate(Runnable runnable) {
+    Map<String, String> contextMap = MDC.getCopyOfContextMap();
+    SecurityContext securityContext = SecurityContextHolder.getContext();
+
+    return () -> {
+      try {
+        // MDC 설정
+        if (contextMap != null) {
+          MDC.setContextMap(contextMap);
+        }
+        // SecurityContext 설정
+        SecurityContextHolder.setContext(securityContext);
+        // 비동기 작업 실행
+        runnable.run();
+      } finally {
+        // MDC 정리
+        MDC.clear();
+        SecurityContextHolder.clearContext();
+      }
+    };
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/config/MetricsConfig.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/MetricsConfig.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.config;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+  @Bean
+  public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+    return new TimedAspect(meterRegistry);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/config/RetryConfig.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+  
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/NotificationController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/NotificationController.java
@@ -1,0 +1,52 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<List<NotificationDto>> getNotifications(
+      @AuthenticationPrincipal DiscodeitUserDetails userDetails
+  ) {
+    UUID recevierId = userDetails.getUserDto().id();
+    log.info("알림 목록 조회 요청: id={}", recevierId);
+    List<NotificationDto> notifications =
+        notificationService.findByRecevierId(recevierId);
+    log.debug("알림 목록 조회 응답: totalElements = {}", notifications.size());
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(notifications);
+  }
+
+  @DeleteMapping("/api/notifications/{notificationId}")
+  public ResponseEntity<Void> deleteNotification(
+      @AuthenticationPrincipal DiscodeitUserDetails userDetails,
+      @PathVariable UUID notificationId) throws AccessDeniedException {
+    UUID receiverId = userDetails.getUserDto().id();
+    notificationService.delete(notificationId, receiverId);
+    return ResponseEntity
+        .status(HttpStatus.NO_CONTENT)
+        .build();
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/data/AsyncTaskFailure.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/data/AsyncTaskFailure.java
@@ -1,0 +1,9 @@
+package com.sprint.mission.discodeit.dto.data;
+
+public record AsyncTaskFailure(
+    String taskName,
+    String requestId,
+    String failureReason
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/data/NotificationDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/data/NotificationDto.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.dto.data;
+
+import com.sprint.mission.discodeit.entity.NotificationType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+    UUID id,
+    Instant createdAt,
+    UUID receiverId,
+    String Title,
+    String content,
+    NotificationType type,
+    UUID targetID
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusUpdateRequest.java
@@ -7,7 +7,9 @@ import java.time.Instant;
 public record ReadStatusUpdateRequest(
     @NotNull(message = "새로운 마지막 읽은 시간은 필수입니다")
     @PastOrPresent(message = "마지막 읽은 시간은 현재 또는 과거 시간이어야 합니다")
-    Instant newLastReadAt
+    Instant newLastReadAt,
+    
+    boolean newNotificationEnabled
 ) {
 
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -3,6 +3,8 @@ package com.sprint.mission.discodeit.entity;
 import com.sprint.mission.discodeit.entity.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,10 +22,21 @@ public class BinaryContent extends BaseEntity {
   private Long size;
   @Column(length = 100, nullable = false)
   private String contentType;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private BinaryContentUploadStatus uploadStatus = BinaryContentUploadStatus.WAITING;
 
   public BinaryContent(String fileName, Long size, String contentType) {
     this.fileName = fileName;
     this.size = size;
     this.contentType = contentType;
+  }
+
+  public void markUploadSuccess() {
+    this.uploadStatus = BinaryContentUploadStatus.SUCCESS;
+  }
+
+  public void markUploadFailed() {
+    this.uploadStatus = BinaryContentUploadStatus.FAILED;
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContentUploadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContentUploadStatus.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.entity;
+
+public enum BinaryContentUploadStatus {
+  WAITING,
+  SUCCESS,
+  FAILED
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
@@ -1,0 +1,34 @@
+package com.sprint.mission.discodeit.entity;
+
+import com.sprint.mission.discodeit.entity.base.BaseUpdatableEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseUpdatableEntity {
+
+  private UUID receiverId;
+  private String title;
+  private String content;
+  @Enumerated(EnumType.STRING)
+  private NotificationType type;
+  private UUID targetId; // Optional
+
+  public Notification(UUID receiverId, String title, String content, NotificationType type,
+      UUID targetId) {
+    this.receiverId = receiverId;
+    this.title = title;
+    this.content = content;
+    this.type = type;
+    this.targetId = targetId;
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "notifications")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Notification extends BaseUpdatableEntity {
 
   private UUID receiverId;

--- a/src/main/java/com/sprint/mission/discodeit/entity/NotificationType.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/NotificationType.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.entity;
+
+public enum NotificationType {
+  NEW_MESSAGE,
+  ROLE_CHANGED,
+  ASYNC_FAILED
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -32,16 +32,20 @@ public class ReadStatus extends BaseUpdatableEntity {
   private Channel channel;
   @Column(columnDefinition = "timestamp with time zone", nullable = false)
   private Instant lastReadAt;
+  @Column(nullable = false)
+  private boolean notificationEnabled;
 
   public ReadStatus(User user, Channel channel, Instant lastReadAt) {
     this.user = user;
     this.channel = channel;
     this.lastReadAt = lastReadAt;
+    this.notificationEnabled = channel.getType() != ChannelType.PUBLIC;
   }
 
-  public void update(Instant newLastReadAt) {
+  public void update(Instant newLastReadAt, Boolean notificationEnabled) {
     if (newLastReadAt != null && !newLastReadAt.equals(this.lastReadAt)) {
       this.lastReadAt = newLastReadAt;
+      this.notificationEnabled = notificationEnabled;
     }
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/event/NotificationEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/NotificationEvent.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.event;
+
+import com.sprint.mission.discodeit.entity.NotificationType;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationEvent {
+
+  private final UUID receiverId;
+  private final NotificationType type;
+  private final String title;
+  private final String content;
+  private final UUID targetId;
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/NotificationEventListener.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/NotificationEventListener.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.event;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+  private NotificationService notificationService;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleNotification(NotificationEvent event) {
+    Notification notification = Notification.builder()
+        .receiverId(event.getReceiverId())
+        .title(event.getTitle())
+        .content(event.getContent())
+        .type(event.getType())
+        .targetId(event.getTargetId())
+        .build();
+
+    notificationService.save(notification);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/mapper/NotificationMapper.java
+++ b/src/main/java/com/sprint/mission/discodeit/mapper/NotificationMapper.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.mapper;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+  NotificationDto toDto(Notification notification);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Notification;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+  List<Notification> findByReceiverId(UUID receiverId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/NotificationService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/NotificationService.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationService {
+
+  List<NotificationDto> findByRecevierId(UUID receiverId);
+
+  void delete(UUID notificationId, UUID receiverId) throws AccessDeniedException;
+
+  void save(Notification notification);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -8,12 +8,15 @@ import com.sprint.mission.discodeit.mapper.BinaryContentMapper;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.service.BinaryContentService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,10 +27,11 @@ public class BasicBinaryContentService implements BinaryContentService {
   private final BinaryContentMapper binaryContentMapper;
   private final BinaryContentStorage binaryContentStorage;
 
+  @Timed(value = "binaryContent.create.time", description = "BinaryContent creation execution time")
   @Transactional
   @Override
   public BinaryContentDto create(BinaryContentCreateRequest request) {
-    log.debug("바이너리 컨텐츠 생성 시작: fileName={}, size={}, contentType={}", 
+    log.debug("바이너리 컨텐츠 생성 시작: fileName={}, size={}, contentType={}",
         request.fileName(), request.bytes().length, request.contentType());
 
     String fileName = request.fileName();
@@ -39,9 +43,13 @@ public class BasicBinaryContentService implements BinaryContentService {
         contentType
     );
     binaryContentRepository.save(binaryContent);
-    binaryContentStorage.put(binaryContent.getId(), bytes);
 
-    log.info("바이너리 컨텐츠 생성 완료: id={}, fileName={}, size={}", 
+    // 트랜잭션 끝나고 비동기 업로드 작업
+    if (binaryContent != null) {
+      updateUploadStatusAfterPut(binaryContent, bytes);
+    }
+
+    log.info("바이너리 컨텐츠 생성 완료: id={}, fileName={}, size={}",
         binaryContent.getId(), fileName, bytes.length);
     return binaryContentMapper.toDto(binaryContent);
   }
@@ -52,7 +60,7 @@ public class BasicBinaryContentService implements BinaryContentService {
     BinaryContentDto dto = binaryContentRepository.findById(binaryContentId)
         .map(binaryContentMapper::toDto)
         .orElseThrow(() -> BinaryContentNotFoundException.withId(binaryContentId));
-    log.info("바이너리 컨텐츠 조회 완료: id={}, fileName={}", 
+    log.info("바이너리 컨텐츠 조회 완료: id={}, fileName={}",
         dto.id(), dto.fileName());
     return dto;
   }
@@ -76,5 +84,36 @@ public class BasicBinaryContentService implements BinaryContentService {
     }
     binaryContentRepository.deleteById(binaryContentId);
     log.info("바이너리 컨텐츠 삭제 완료: id={}", binaryContentId);
+  }
+
+  private void updateUploadStatusAfterPut(BinaryContent binaryContent, byte[] profileBytes) {
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronizationAdapter() {
+          public void afterCommit() {
+            try {
+              // 비동기 put 호출
+              UUID uploadedId = binaryContentStorage.put(
+                  binaryContent.getId(), profileBytes);
+
+              // BinaryContent 조회 및 상태 업데이트
+              BinaryContent updatedContent = binaryContentRepository.findById(
+                      binaryContent.getId())
+                  .orElseThrow(
+                      () -> BinaryContentNotFoundException.withId(binaryContent.getId()));
+
+              if (uploadedId != null) {
+                updatedContent.markUploadSuccess();
+              } else {
+                updatedContent.markUploadFailed();
+              }
+              binaryContentRepository.save(updatedContent); // 상태 저장
+              log.info("업로드 상태 업데이트 완료: ID = {}, 상태 = {}",
+                  binaryContent.getId(), updatedContent.getUploadStatus());
+            } catch (Exception e) {
+              log.error("afterCommit 중 업로드 실패: ID = {}, 오류 = {}",
+                  binaryContent.getId(), e.getMessage());
+            }
+          }
+        });
   }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicNotificationService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicNotificationService.java
@@ -1,0 +1,46 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import com.sprint.mission.discodeit.mapper.NotificationMapper;
+import com.sprint.mission.discodeit.repository.NotificationRepository;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BasicNotificationService implements NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final NotificationMapper notificationMapper;
+
+  // 본인 notifications return
+  @Override
+  public List<NotificationDto> findByRecevierId(UUID receiverId) {
+    return notificationRepository.findByReceiverId(receiverId)
+        .stream()
+        .map(notificationMapper::toDto)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void delete(UUID notificationId, UUID receiverId) throws AccessDeniedException {
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new RuntimeException("알림이 존재하지 않습니다."));
+    if (!Objects.equals(notification.getReceiverId(), receiverId)) {
+      throw new AccessDeniedException("자신의 알림만 삭제할 수 있습니다.");
+    }
+    notificationRepository.deleteById(notificationId);
+  }
+
+  // 알림 저장
+  public void save(Notification notification) {
+    notificationRepository.save(notification);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -90,7 +90,7 @@ public class BasicReadStatusService implements ReadStatusService {
 
     ReadStatus readStatus = readStatusRepository.findById(readStatusId)
         .orElseThrow(() -> ReadStatusNotFoundException.withId(readStatusId));
-    readStatus.update(request.newLastReadAt());
+    readStatus.update(request.newLastReadAt(), request.newNotificationEnabled());
 
     log.info("읽음 상태 수정 완료: id={}", readStatusId);
     return readStatusMapper.toDto(readStatus);

--- a/src/main/java/com/sprint/mission/discodeit/storage/local/LocalBinaryContentStorage.java
+++ b/src/main/java/com/sprint/mission/discodeit/storage/local/LocalBinaryContentStorage.java
@@ -1,5 +1,6 @@
 package com.sprint.mission.discodeit.storage.local;
 
+import com.sprint.mission.discodeit.dto.data.AsyncTaskFailure;
 import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
 import jakarta.annotation.PostConstruct;
@@ -10,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.InputStreamResource;
@@ -17,8 +20,13 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @ConditionalOnProperty(name = "discodeit.storage.type", havingValue = "local")
 @Component
 public class LocalBinaryContentStorage implements BinaryContentStorage {
@@ -43,19 +51,41 @@ public class LocalBinaryContentStorage implements BinaryContentStorage {
     }
   }
 
+  //  @Async
+  @Retryable(
+      retryFor = {RuntimeException.class}, // 재시도할 예외 유형
+      maxAttempts = 3, // 최대 재시도 횟수 (최초 시도 포함, 총 3회)
+      backoff = @Backoff(delay = 1000, maxDelay = 5000) // 대기 시간 ( 초기 1초, 최대 5초 )
+  )
   public UUID put(UUID binaryContentId, byte[] bytes) {
     Path filePath = resolvePath(binaryContentId);
     if (Files.exists(filePath)) {
       throw new IllegalArgumentException("File with key " + binaryContentId + " already exists");
     }
-    try (OutputStream outputStream = Files.newOutputStream(filePath)) {
-      outputStream.write(bytes);
-    } catch (IOException e) {
+    try {
+      Thread.sleep(2000);
+      try (OutputStream outputStream = Files.newOutputStream(filePath)) {
+        outputStream.write(bytes);
+      }
+    } catch (IOException | InterruptedException e) {
       throw new RuntimeException(e);
     }
     return binaryContentId;
   }
 
+  @Recover
+  public UUID recoverPut(RuntimeException e, UUID binaryContentId, byte[] bytes) {
+    Throwable cause = e.getCause();
+    String failureReason = (cause instanceof IOException) ? cause.getMessage() : e.getMessage();
+    String requestId = MDC.get("requestId");
+
+    AsyncTaskFailure failure = new AsyncTaskFailure("Local putMethod", requestId, failureReason);
+
+    log.error("업로드 실패: {}, 컨텐츠 ID: {}", failure, binaryContentId);
+
+    return null;
+  }
+  
   public InputStream get(UUID binaryContentId) {
     Path filePath = resolvePath(binaryContentId);
     if (Files.notExists(filePath)) {

--- a/src/main/java/com/sprint/mission/discodeit/storage/local/LocalBinaryContentStorage.java
+++ b/src/main/java/com/sprint/mission/discodeit/storage/local/LocalBinaryContentStorage.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -32,11 +33,14 @@ import org.springframework.stereotype.Component;
 public class LocalBinaryContentStorage implements BinaryContentStorage {
 
   private final Path root;
+  private final ApplicationEventPublisher eventPublisher;
 
   public LocalBinaryContentStorage(
-      @Value("${discodeit.storage.local.root-path}") Path root
+      @Value("${discodeit.storage.local.root-path}") Path root,
+      ApplicationEventPublisher eventPublisher
   ) {
     this.root = root;
+    this.eventPublisher = eventPublisher;
   }
 
   @PostConstruct
@@ -85,7 +89,7 @@ public class LocalBinaryContentStorage implements BinaryContentStorage {
 
     return null;
   }
-  
+
   public InputStream get(UUID binaryContentId) {
     Path filePath = resolvePath(binaryContentId);
     if (Files.notExists(filePath)) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,11 @@ management:
   endpoint:
     health:
       show-details: always
+    logfile:
+      external-file:
+    web:
+      exposure:
+        include: metrics
 
 info:
   name: Discodeit


### PR DESCRIPTION
# 요구사항

## 기본 요구사항

### 비동기 적용하기
- [x] BinaryContentStorage의 파일 업로드 로직을 비동기적으로 처리하세요.
  - 비동기 처리 시 MDC의 Request ID, SecurityContext의 인증 정보가 유지되도록 하세요.
- [x] 업로드 중 예외가 발생한 경우, 자동 재시도 메커니즘을 구현하세요.
  - Spring Retry의 @Retryable 어노테이션을 사용해 재시도 정책(횟수, 대기 시간 등)을 설정하세요.
- [x] 재시도 횟수를 초과한 경우, 실패 정보(AsyncTaskFailure)를 기록하는 복구 로직을 실행하세요.
  - @Recover 어노테이션을 사용해 재시도 실패 처리 메서드를 구현하세요.
  - 실패 정보(AsyncTaskFailure)에는 MDC의 Request ID를 포함하여 추적이 가능하도록 하세요.
- [x] 파일 업로드 메소드를 호출한 곳(BasicMessageService, BasicUserService 등)에서 비동기 처리 성공/실패에 따라 BinaryContent의 상태를 업데이트 하세요.
  - BinaryContent 엔티티에 업로드 상태를 나타내는 속성(uploadStatus)을 추가하세요.
    - WAITING: 업로드 대기 중 (파일 저장 요청만 완료된 상태)
    - SUCCESS: 업로드 완료
    - FAILED: 업로드 실패 (모든 재시도 실패)
  - WAITING으로 초기화하세요.
  - 업로드 성공 시, SUCCESS로 업데이트하세요.
  - 업로드 실패 시, FAILED로 업데이트하세요.
    - 의도적인 예외를 발생시켜 테스트해보세요.
```
경우에 따라 비동기 업로드 로직이 메인 스레드의 트랜잭션보다 일찍 종료되는 경우 업데이트할 BinaryContent 데이터가 DB에 반영되지 않아 업데이트가 정상적으로 이루어지지 않을 수 있습니다.
따라서 메인 스레드의 트랜잭션이 끝난 시점까지 대기해야 합니다.

TransactionSynchronizationManager.registerSynchronization를 활용해 트랜잭션이 성공적으로 커밋되었을 때 실행할 작업을 정의할 수 있습니다.
@Transactional
@Override
public MessageDto create(MessageCreateRequest messageCreateRequest,
    List<BinaryContentCreateRequest> binaryContentCreateRequests) {
                ... 
        TransactionSynchronizationManager.registerSynchronization(
            new TransactionSynchronization() {
              @Override
              public void afterCommit() {
                // 비동기 로직...
              }
            }
        );
        ...
}
@TransactionalEventListener를 활용할 수도 있습니다.
```
- [x] 동기 처리와 비동기 처리 간의 성능 차이를 비교해보세요.
- 파일 업로드 로직에 의도적인 지연(Thread.sleep(...))을 발생시키세요.
- @Timed 어노테이션을 활용하여 API의 실행 시간을 측정하고, 동기/비동기 처리 방식 간 응답 속도 차이를 분석하고 PR에 해당 내용을 포함하세요.

### 알림 기능 추가하기
- [x] ReadStatus 엔티티를 리팩토링하세요.
  - 새로운 메시지에 대한 알림 활성화 여부를 관리하는 속성(notificationEnabled)을 추가하세요.
  - 사용자가 해당 알림 설정을 변경할 수 있게 API를 수정하세요.
  - PRIVATE 채널은 알림을 활성화하는 것을 기본으로 합니다.
  - PUBLIC 채널은 알림을 비활성화하는 것을 기본으로 합니다.
- [x] 알림 관련 API를 구현하세요.
  - 알림 조회 및 삭제 시 현재 요청의 인증 정보로 요청자를 식별합니다.
  - 알림 확인은 삭제를 통해 수행합니다.
  - receiverId: 알림을 수신할 User의 id입니다.
  - targetId는 optional 입니다.
- [ ] 다음 상황 발생 시, 해당 사용자에게 알림을 발행하세요.
  - 사용자가 알림을 활성화한 채팅방(ReadStatus.notificationEnabled == true)에 메시지가 등록된 경우
    - type: NEW_MESSAGE, targetId: channelId
  - 사용자의 권한(Role)이 변경된 경우
    - type: ROLE_CHANGED, targetId: userId
  - 해당 사용자의 요청에서 발생한 비동기 작업이 실패하여 실패 로그가 기록된 경우
    - type: ASYNC_FAILED, targetId: null
- [x] 알림은 Spring Event 기반의 비동기 방식으로 발행되도록 구현하세요.
  - @Async + @EventListener 구조로 비동기 처리하세요.
  - 이벤트 처리 중 실패가 발생할 경우, 자동 재시도 메커니즘을 도입하세요.
  - 이벤트 발행 및 리스닝은 트랜잭션 경계(transaction boundary)를 고려하여 수행하세요.
    - @TransactionalEventListener

### 캐시 적용하기
- [ ] Caffeine 캐시를 적용하세요.
- [ ] 캐시가 필요하다고 판단되는 로직에 캐시를 적용하세요.
  - 예시:
    - 사용자별 채널 목록 조회
    - 사용자별 알림 목록 조회
    - 사용자 목록 조회
- [ ] 데이터 변경 시, 캐시를 갱신 또는 무효화하는 로직을 구현하세요.
  - @CacheEvict, @CachePut, Spring Event 등을 활용하세요.
  - 예시:
    - 새로운 채널 추가 → 채널 목록 캐시 무효화
    - 알림 추가 → 알림 목록 캐시 무효화
    - 채널에 사용자 추가 → 사용자 목록 캐시 무효화
- [ ] 캐시 적용 전후의 차이를 비교해보세요.
  - SQL 실행 횟수
  - 응답 시간

## 심화 요구사항
### Spring Kafka 도입하기
- 알림 기능이 별도의 애플리케이션으로 분리된다고 가정해봅시다.
- Spring Event를 통해 발행/소비했던 이벤트는 더 이상 활용할 수 없습니다.
- 대신, Kafka와 같은 메시지 브로커를 통해 이벤트를 애플케이션 간 발행/구독할 수 있습니다.
- [ ] Kafka 환경을 구성하세요.
  - Docker Compose를 활용해 Kafka를 구동하세요.
  - Spring Kafka 의존성을 추가하고, application.yml에 Kafka 설정을 추가하세요.
- [ ] Spring Event → Kafka 중계 핸들러(KafkaHandler)를 구현하세요.
  - 앞서 구현한 Spring Event 발행 코드는 유지하세요.
  - @EventListener / @TransactionalEventListener와 KafkaTemplate을 활용해 발행된 Spring Event를 Kafka 메시지로 변환해 전송하는 중계 구조를 구성하세요.
  - 기존에 사용하던 Spring Event 발행 코드를 유지하면서, 내부적으로 Kafka로 메시지를 전송하는 중계 구조를 구성하세요.    
- [ ] Kafka Console을 통해 Kafka 이벤트가 잘 발행되는지 확인해보세요.
- [ ] NotificationHandler를 Kafka Consumer 기반으로 리팩토링하세요.
  - 기존 @EventListener 기반 로직을 제거하고 @KafkaListener로 대체하세요.

### Redis Cache 도입하기
- 대용량 트래픽을 감당하기 위해 서버의 인스턴스를 여러 개로 늘렸다고 가정해봅시다.
- Caffeine과 같은 로컬 캐시는 서로 다른 서버에서 더 이상 활용할 수 없습니다. 
따라서 Redis를 통해 전역 캐시 저장소를 구성합니다.
- [ ] Redis 환경을 구성하세요.
  - Docker Compose를 활용해 Redis를 구동하세요.
  - Caffeine 의존성은 삭제 / Redis 의존성을 추가하고, application.yml에 Kafka 설정을 추가하세요.
- [ ] DataGrip을 통해 Redis에 저장된 캐시 정보를 조회해보세요.


## 주요 변경사항


## 스크린샷

 
## 멘토님에게